### PR TITLE
Add base code for web API

### DIFF
--- a/packages/common/src/build-utilities/monorepo-packages.spec.ts
+++ b/packages/common/src/build-utilities/monorepo-packages.spec.ts
@@ -6,13 +6,14 @@ import { listMonorepoPackageNames } from './monorepo-packages';
 describe('listMonorepoPackageNames', () => {
     it('returns the pinned set of package names', () => {
         expect(listMonorepoPackageNames()).toMatchInlineSnapshot(`
-            Array [
-              "azure-services",
-              "common",
-              "logger",
-              "resource-deployment",
-              "storage-documents",
-            ]
-        `);
+Array [
+  "azure-services",
+  "common",
+  "logger",
+  "resource-deployment",
+  "service-library",
+  "storage-documents",
+]
+`);
     });
 });

--- a/packages/common/src/build-utilities/monorepo-packages.spec.ts
+++ b/packages/common/src/build-utilities/monorepo-packages.spec.ts
@@ -6,14 +6,14 @@ import { listMonorepoPackageNames } from './monorepo-packages';
 describe('listMonorepoPackageNames', () => {
     it('returns the pinned set of package names', () => {
         expect(listMonorepoPackageNames()).toMatchInlineSnapshot(`
-Array [
-  "azure-services",
-  "common",
-  "logger",
-  "resource-deployment",
-  "service-library",
-  "storage-documents",
-]
-`);
+            Array [
+              "azure-services",
+              "common",
+              "logger",
+              "resource-deployment",
+              "service-library",
+              "storage-documents",
+            ]
+        `);
     });
 });

--- a/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
+++ b/packages/common/src/configuration/__snapshots__/service-configuration.spec.ts.snap
@@ -21,6 +21,18 @@ Object {
       "format": "int",
     },
   },
+  "restApiConfig": Object {
+    "maxScanPriorityValue": Object {
+      "default": 1000,
+      "doc": "Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.                        This range correlates with Azure Batch pool task priority range.",
+      "format": "int",
+    },
+    "minScanPriorityValue": Object {
+      "default": -1000,
+      "doc": "Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.                        This range correlates with Azure Batch pool task priority range.",
+      "format": "int",
+    },
+  },
 }
 `;
 
@@ -42,6 +54,18 @@ Object {
     "messageVisibilityTimeoutInSeconds": Object {
       "default": 2700,
       "doc": "Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes config value.",
+      "format": "int",
+    },
+  },
+  "restApiConfig": Object {
+    "maxScanPriorityValue": Object {
+      "default": 1000,
+      "doc": "Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.                        This range correlates with Azure Batch pool task priority range.",
+      "format": "int",
+    },
+    "minScanPriorityValue": Object {
+      "default": -1000,
+      "doc": "Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.                        This range correlates with Azure Batch pool task priority range.",
       "format": "int",
     },
   },

--- a/packages/common/src/configuration/service-configuration.ts
+++ b/packages/common/src/configuration/service-configuration.ts
@@ -15,9 +15,15 @@ export interface LogRuntimeConfig {
     logInConsole: boolean;
 }
 
+export interface RestApiConfig {
+    minScanPriorityValue: number;
+    maxScanPriorityValue: number;
+}
+
 export interface RuntimeConfig {
     logConfig: LogRuntimeConfig;
     queueConfig: QueueRuntimeConfig;
+    restApiConfig: RestApiConfig;
 }
 
 export declare type ResourceType = 'batch' | 'registry';
@@ -90,6 +96,20 @@ export class ServiceConfiguration {
                     format: 'int',
                     default: 30 * 1.5 * 60, // maxWallClockTimeInMinutes * delta termination wait time
                     doc: 'Message visibility timeout in seconds. Must correlate with jobManagerConfig.maxWallClockTimeInMinutes config value.',
+                },
+            },
+            restApiConfig: {
+                minScanPriorityValue: {
+                    format: 'int',
+                    default: -1000,
+                    doc: 'Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.\
+                        This range correlates with Azure Batch pool task priority range.',
+                },
+                maxScanPriorityValue: {
+                    format: 'int',
+                    default: 1000,
+                    doc: 'Priority values can range from -1000 to 1000, with -1000 being the lowest priority and 1000 being the highest priority.\
+                        This range correlates with Azure Batch pool task priority range.',
                 },
             },
         };

--- a/packages/service-library/.vscode/tasks.json
+++ b/packages/service-library/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "tsc",
+            "command": "tsc",
+            "isShellCommand": true,
+            "showOutput": "silent",
+            "args": [],
+            "problemMatcher": ["$tsc"]
+        }
+    ]
+}

--- a/packages/service-library/jest.config.js
+++ b/packages/service-library/jest.config.js
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../jest.config.base');
+const package = require('./package');
+
+module.exports = {
+    ...baseConfig,
+    displayName: package.name,
+};

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "service-library",
+    "version": "1.0.0",
+    "description": "This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.",
+    "scripts": {
+        "build": "tsc && echo",
+        "cbuild": "npm-run-all --serial clean build",
+        "clean": "rimraf dist test-results",
+        "lint": "eslint -c ../../.eslintrc.js --ext .ts ./",
+        "lint:fix": "eslint --fix -c ../../.eslintrc.js --ext .ts ./",
+        "test": "jest --coverage --colors"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Microsoft/web-insights-service.git"
+    },
+    "main": "dist/index.js",
+    "author": "Microsoft",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Microsoft/web-insights-service/issues"
+    },
+    "homepage": "https://github.com/Microsoft/web-insights-service#readme",
+    "devDependencies": {
+        "@types/jest": "^26.0.23",
+        "@types/node": "^12.20.14",
+        "jest": "^27.0.3",
+        "jest-extended": "^0.11.5",
+        "jest-junit": "^12.1.0",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^27.0.2",
+        "typemoq": "^2.1.0",
+        "typescript": "^4.3.2"
+    },
+    "dependencies": {
+        "@azure/functions": "^1.2.3",
+        "common": "^1.0.0",
+        "dotenv": "^10.0.0",
+        "inversify": "^5.0.5",
+        "lodash": "^4.17.21",
+        "logger": "1.0.0",
+        "reflect-metadata": "^0.1.13"
+    }
+}

--- a/packages/service-library/prettier.config.js
+++ b/packages/service-library/prettier.config.js
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const baseConfig = require('../../prettier.config');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/packages/service-library/src/global.d.ts
+++ b/packages/service-library/src/global.d.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// eslint-disable-next-line import/no-unassigned-import
+import 'jest-extended';

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export { ProcessEntryPointBase } from './process-entry-point-base';
+export * from './web-api/web-api-ioc-types';
+export { WebController } from './web-api/web-controller';
+export { ApiController } from './web-api/api-controller';
+export { WebControllerDispatcher } from './web-api/web-controller-dispatcher';
+export { getGlobalWebControllerDispatcher } from './web-api/get-global-web-controller-dispatcher';
+export * from './web-api/web-api-error-codes';
+export { HttpResponse } from './web-api/http-response';

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 export { ProcessEntryPointBase } from './process-entry-point-base';
-export * from './web-api/web-api-ioc-types';
 export { WebController } from './web-api/web-controller';
 export { ApiController } from './web-api/api-controller';
 export { WebControllerDispatcher } from './web-api/web-controller-dispatcher';

--- a/packages/service-library/src/process-entry-point-base.spec.ts
+++ b/packages/service-library/src/process-entry-point-base.spec.ts
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { System } from 'common';
+import { DotenvConfigOutput } from 'dotenv';
+import { Container } from 'inversify';
+import * as _ from 'lodash';
+import { BaseTelemetryProperties, GlobalLogger, loggerTypes } from 'logger';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { ProcessEntryPointBase } from './process-entry-point-base';
+import { MockableLogger } from './test-utilities/mockable-logger';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class TestEntryPoint extends ProcessEntryPointBase {
+    public baseTelemetryProperties: BaseTelemetryProperties = { source: 'test-source', someOtherProps: 'foo' };
+
+    public customActionInvoked = false;
+
+    public customActionArgs: any[];
+
+    public customActionToBeInvoked: () => void;
+
+    protected getTelemetryBaseProperties(): BaseTelemetryProperties {
+        return this.baseTelemetryProperties;
+    }
+
+    protected async runCustomAction(container: Container, ...args: any[]): Promise<void> {
+        if (!_.isNil(this.customActionToBeInvoked)) {
+            this.customActionToBeInvoked();
+        }
+        this.customActionInvoked = true;
+        this.customActionArgs = args;
+    }
+}
+
+describe(ProcessEntryPointBase, () => {
+    let testSubject: TestEntryPoint;
+    let loggerMock: IMock<MockableLogger>;
+    let dotEnvConfigStub: DotenvConfigOutput;
+    let containerMock: IMock<Container>;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType(MockableLogger);
+        dotEnvConfigStub = {};
+        containerMock = Mock.ofType(Container);
+
+        testSubject = new TestEntryPoint(containerMock.object);
+    });
+
+    describe('start', () => {
+        it('verifies dotenv is loaded first', async () => {
+            loggerMock.reset();
+            const errorMsg = 'dotEnvLoadedFirst';
+            containerMock
+                .setup((c) => c.get(loggerTypes.DotEnvConfig))
+                .returns(() => {
+                    throw errorMsg;
+                });
+            containerMock
+                .setup((c) => c.get(It.is((val) => val !== loggerTypes.DotEnvConfig && val !== loggerTypes.Process)))
+                .verifiable(Times.never());
+
+            await expect(testSubject.start()).rejects.toEqual(errorMsg);
+
+            expect(testSubject.customActionInvoked).toBe(false);
+            verifyNoLoggingCalls();
+            verifyLogFlushCall(Times.never());
+            verifyMocks();
+        });
+
+        it('return log setup failure', async () => {
+            loggerMock.reset();
+            const errorMsg = 'logger setup error';
+            setupContainerForDotEnvConfig();
+            setupContainerForLogger();
+            loggerMock.setup(async (l) => l.setup(testSubject.baseTelemetryProperties)).returns(async () => Promise.reject(errorMsg));
+
+            await expect(testSubject.start()).rejects.toEqual(errorMsg);
+
+            verifyNoLoggingCalls();
+            verifyLogFlushCall(Times.never());
+            verifyMocks();
+        });
+
+        describe('logging for dotEnvConfig', () => {
+            beforeEach(() => {
+                setupContainerForDotEnvConfig();
+                setupContainerForLogger();
+                setupLoggerSetupCall();
+            });
+
+            it('verifies logging for valid data', async () => {
+                dotEnvConfigStub = { parsed: { foo: 'bar' } };
+
+                loggerMock
+                    .setup((l) =>
+                        l.logInfo(
+                            `Loaded environment variables from the .env config file.\n${JSON.stringify(
+                                dotEnvConfigStub.parsed,
+                                undefined,
+                                2,
+                            )}`,
+                        ),
+                    )
+                    .verifiable();
+
+                await expect(testSubject.start()).resolves.toBeUndefined();
+
+                verifyLogFlushCall();
+                verifyMocks();
+            });
+
+            it('verifies logging for invalid data', async () => {
+                dotEnvConfigStub = { error: new Error('error1') };
+
+                loggerMock.setup((l) => l.logWarn(`Unable to load the .env config file. ${dotEnvConfigStub.error}`)).verifiable();
+
+                await expect(testSubject.start()).resolves.toBeUndefined();
+
+                verifyLogFlushCall();
+                verifyMocks();
+            });
+        });
+
+        describe('runCustomAction', () => {
+            beforeEach(() => {
+                setupContainerForDotEnvConfig();
+                setupContainerForLogger();
+                setupLoggerSetupCall();
+                dotEnvConfigStub = { parsed: { foo: 'bar' } };
+            });
+
+            it('invoked when start is called', async () => {
+                await expect(testSubject.start()).resolves.toBeUndefined();
+
+                expect(testSubject.customActionInvoked).toBe(true);
+
+                verifyLogFlushCall();
+                verifyMocks();
+            });
+
+            it('invoked when start is called with args', async () => {
+                await expect(testSubject.start(1, 2)).resolves.toBeUndefined();
+
+                expect(testSubject.customActionInvoked).toBe(true);
+                expect(testSubject.customActionArgs).toEqual([1, 2]);
+
+                verifyLogFlushCall();
+                verifyMocks();
+            });
+
+            it('logs exception thrown', async () => {
+                const error = new Error('error in custom action');
+                testSubject.customActionToBeInvoked = () => {
+                    throw error;
+                };
+                loggerMock
+                    .setup((l) =>
+                        l.logError(
+                            'Error occurred while executing main process.',
+                            It.is((o) => _.isEqual(o.error, System.serializeError(error))),
+                        ),
+                    )
+                    .verifiable();
+
+                await expect(testSubject.start()).rejects.toEqual(error);
+
+                verifyLogFlushCall();
+                verifyMocks();
+            });
+        });
+    });
+
+    function verifyMocks(): void {
+        loggerMock.verifyAll();
+        containerMock.verifyAll();
+    }
+
+    function verifyNoLoggingCalls(): void {
+        loggerMock.verify((l) => l.log(It.isAny(), It.isAny(), It.isAny()), Times.never());
+        loggerMock.verify((l) => l.logInfo(It.isAny(), It.isAny()), Times.never());
+        loggerMock.verify((l) => l.logVerbose(It.isAny(), It.isAny()), Times.never());
+        loggerMock.verify((l) => l.trackEvent(It.isAny(), It.isAny()), Times.never());
+        loggerMock.verify((l) => l.trackMetric(It.isAny(), It.isAny()), Times.never());
+        loggerMock.verify((l) => l.logError(It.isAny(), It.isAny()), Times.never());
+    }
+
+    function verifyLogFlushCall(times: Times = Times.once()): void {
+        loggerMock.verify((l) => l.flush(), times);
+    }
+
+    function setupContainerForDotEnvConfig(): void {
+        containerMock
+            .setup((c) => c.get(loggerTypes.DotEnvConfig))
+            .returns(() => dotEnvConfigStub)
+            .verifiable();
+    }
+
+    function setupContainerForLogger(): void {
+        containerMock
+            .setup((c) => c.get(GlobalLogger))
+            .returns(() => loggerMock.object)
+            .verifiable();
+    }
+
+    function setupLoggerSetupCall(): void {
+        loggerMock
+            .setup(async (l) => l.setup(testSubject.baseTelemetryProperties))
+            .returns(async () => Promise.resolve())
+            .verifiable();
+    }
+});

--- a/packages/service-library/src/process-entry-point-base.ts
+++ b/packages/service-library/src/process-entry-point-base.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { System } from 'common';
+import { DotenvConfigOutput } from 'dotenv';
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, GlobalLogger, loggerTypes } from 'logger';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export abstract class ProcessEntryPointBase {
+    constructor(private readonly container: Container) {}
+
+    public async start(...args: any[]): Promise<void> {
+        let loggerInitialized = false;
+        let logger: GlobalLogger;
+
+        try {
+            const dotEnvConfig: DotenvConfigOutput = this.container.get(loggerTypes.DotEnvConfig);
+
+            logger = this.container.get(GlobalLogger);
+            await logger.setup(this.getTelemetryBaseProperties());
+            loggerInitialized = true;
+
+            this.verifyDotEnvParsing(dotEnvConfig, logger);
+
+            await this.runCustomAction(this.container, ...args);
+        } catch (error) {
+            if (loggerInitialized === true) {
+                logger.logError('Error occurred while executing main process.', { error: System.serializeError(error) });
+            } else {
+                console.log('Error occurred while executing main process.', { error: System.serializeError(error) });
+            }
+            throw error;
+        } finally {
+            if (loggerInitialized === true) {
+                logger.logInfo('Flushing telemetry events.');
+                await logger.flush();
+            }
+        }
+    }
+
+    protected abstract getTelemetryBaseProperties(): BaseTelemetryProperties;
+
+    protected abstract runCustomAction(container: Container, ...args: any[]): Promise<void>;
+
+    private verifyDotEnvParsing(dotEnvConfig: DotenvConfigOutput, logger: GlobalLogger): void {
+        if (dotEnvConfig.parsed !== undefined) {
+            logger.logInfo(`Loaded environment variables from the .env config file.\n${JSON.stringify(dotEnvConfig.parsed, undefined, 2)}`);
+        }
+
+        if (dotEnvConfig.error !== undefined) {
+            logger.logWarn(`Unable to load the .env config file. ${dotEnvConfig.error}`);
+        }
+    }
+}

--- a/packages/service-library/src/test-utilities/mockable-logger.ts
+++ b/packages/service-library/src/test-utilities/mockable-logger.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Logger } from 'logger';
+
+export class MockableLogger extends Logger {}

--- a/packages/service-library/src/web-api/api-controller.spec.ts
+++ b/packages/service-library/src/web-api/api-controller.spec.ts
@@ -1,0 +1,355 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Context } from '@azure/functions';
+import { RestApiConfig, ServiceConfiguration } from 'common';
+import { Logger } from 'logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { ApiController } from './api-controller';
+import { HttpResponse } from './http-response';
+import { WebApiErrorCodes } from './web-api-error-codes';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class TestableApiController extends ApiController {
+    public readonly apiVersion = '1.0';
+
+    public readonly apiName = 'web-api-test';
+
+    public handleRequestInvoked = false;
+
+    public args: any[];
+
+    public constructor(logger: Logger, public requestContext: Context = null, public readonly serviceConfig: ServiceConfiguration = null) {
+        super(logger);
+        this.context = requestContext;
+    }
+
+    public async handleRequest(...requestArgs: any[]): Promise<void> {
+        this.handleRequestInvoked = true;
+        this.args = requestArgs;
+    }
+
+    public validateRequest(): boolean {
+        return super.validateRequest();
+    }
+
+    public validateContentType(): boolean {
+        return super.validateContentType();
+    }
+
+    public validateApiVersion(): boolean {
+        return super.validateApiVersion();
+    }
+
+    public async getRestApiConfig(): Promise<RestApiConfig> {
+        return super.getRestApiConfig();
+    }
+}
+
+describe(ApiController, () => {
+    let loggerMock: IMock<MockableLogger>;
+    beforeEach(() => {
+        loggerMock = Mock.ofType(MockableLogger);
+    });
+
+    describe('validateContentType()', () => {
+        it('should not fail content validation on non POST or PUT', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'GET',
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual(undefined);
+            expect(valid).toEqual(true);
+        });
+
+        it('should detect empty body for POST', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual({ status: 204 });
+            expect(valid).toEqual(false);
+        });
+
+        it('should detect empty body for PUT', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'PUT',
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual({ status: 204 });
+            expect(valid).toEqual(false);
+        });
+
+        it('should fail when no HTTP headers present', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader));
+            expect(valid).toEqual(false);
+        });
+
+        it('should fail when missing content-type HTTP header', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: { host: 'localhost' },
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader));
+            expect(valid).toEqual(false);
+        });
+
+        it('should fail when non valid content-type HTTP header', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: {},
+                },
+            });
+            context.req.headers['content-type'] = 'text/plain';
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedContentType));
+            expect(valid).toEqual(false);
+        });
+
+        it('should accept valid content-type HTTP header', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: {},
+                },
+            });
+            context.req.headers['content-type'] = 'application/json';
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateContentType();
+            expect(context.res).toEqual(undefined);
+            expect(valid).toEqual(true);
+        });
+    });
+
+    describe('validateApiVersion()', () => {
+        it('should fail when missing api-version query param', () => {
+            const context = <Context>(<unknown>{
+                req: {},
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateApiVersion();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter));
+            expect(valid).toEqual(false);
+        });
+
+        it('should fail when invalid api-version query param value', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    query: {},
+                },
+            });
+            context.req.query['api-version'] = '3.0';
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateApiVersion();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+            expect(valid).toEqual(false);
+        });
+
+        it('should accept valid api-version', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    query: {},
+                },
+            });
+            context.req.query['api-version'] = '1.0';
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateApiVersion();
+            expect(context.res).toEqual(undefined);
+            expect(valid).toEqual(true);
+        });
+    });
+
+    describe('hasPayload()', () => {
+        it('should detect no payload in request', () => {
+            const context = <Context>(<unknown>{
+                req: {},
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.hasPayload();
+            expect(valid).toEqual(false);
+        });
+
+        it('should detect empty payload in request', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    rawBody: `[]`,
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.hasPayload();
+
+            expect(valid).toEqual(false);
+        });
+
+        it('should detect payload in request', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    rawBody: `{ "id": "1" }`,
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.hasPayload();
+            expect(valid).toEqual(true);
+        });
+    });
+
+    describe('validateRequest()', () => {
+        it('should reject invalid request', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateRequest();
+            expect(valid).toEqual(false);
+        });
+
+        it('should accept valid request', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: {},
+                    query: {},
+                },
+            });
+            context.req.query['api-version'] = '1.0';
+            context.req.headers['content-type'] = 'application/json';
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const valid = apiControllerMock.validateRequest();
+            expect(valid).toEqual(true);
+        });
+    });
+
+    describe('invoke()', () => {
+        it('should not handle invalid request', async () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object);
+            expect(apiControllerMock.context).toBeNull();
+            await apiControllerMock.invoke(context);
+            expect(apiControllerMock.handleRequestInvoked).toEqual(false);
+        });
+
+        it('should handle valid request', async () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: {},
+                    query: {},
+                },
+            });
+            context.req.query['api-version'] = '1.0';
+            context.req.headers['content-type'] = 'application/json';
+            const apiControllerMock = new TestableApiController(loggerMock.object);
+            expect(apiControllerMock.context).toBeNull();
+            await apiControllerMock.invoke(context);
+            expect(apiControllerMock.handleRequestInvoked).toEqual(true);
+        });
+
+        it('should pass request args', async () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    method: 'POST',
+                    rawBody: `{ "id": "1" }`,
+                    headers: {},
+                    query: {},
+                },
+            });
+            context.req.query['api-version'] = '1.0';
+            context.req.headers['content-type'] = 'application/json';
+            const apiControllerMock = new TestableApiController(loggerMock.object);
+            await apiControllerMock.invoke(context, 'a', 1);
+            expect(apiControllerMock.handleRequestInvoked).toEqual(true);
+            expect(apiControllerMock.args).toEqual(['a', 1]);
+        });
+    });
+
+    describe('tryGetPayload()', () => {
+        interface PayloadType {
+            id: number;
+        }
+
+        it('should detect invalid content', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    rawBody: `{ "id": "1"`,
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const payload = apiControllerMock.tryGetPayload<PayloadType>();
+            expect(payload).toEqual(undefined);
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidJsonDocument));
+        });
+
+        it('should parse valid content', () => {
+            const context = <Context>(<unknown>{
+                req: {
+                    rawBody: `{ "id": "1" }`,
+                },
+            });
+            const apiControllerMock = new TestableApiController(loggerMock.object, context);
+            const payload = apiControllerMock.tryGetPayload<PayloadType>();
+            expect(payload).toEqual({ id: '1' });
+        });
+    });
+
+    describe('getRestApiConfig()', () => {
+        it('should get config value', async () => {
+            const context = <Context>(<unknown>{});
+            const configStub: RestApiConfig = {
+                minScanPriorityValue: -1,
+                maxScanPriorityValue: 1,
+            };
+
+            const serviceConfigMock = Mock.ofType(ServiceConfiguration);
+            serviceConfigMock
+                .setup(async (sm) => sm.getConfigValue('restApiConfig'))
+                .returns(async () => {
+                    return Promise.resolve(configStub);
+                })
+                .verifiable(Times.once());
+
+            const apiControllerMock = new TestableApiController(loggerMock.object, context, serviceConfigMock.object);
+            const actualConfig = await apiControllerMock.getRestApiConfig();
+
+            expect(actualConfig).toEqual(configStub);
+            serviceConfigMock.verifyAll();
+        });
+    });
+});

--- a/packages/service-library/src/web-api/api-controller.ts
+++ b/packages/service-library/src/web-api/api-controller.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RestApiConfig, ServiceConfiguration } from 'common';
+import { injectable } from 'inversify';
+import { isEmpty } from 'lodash';
+import { HttpResponse } from './http-response';
+import { WebApiErrorCodes } from './web-api-error-codes';
+import { WebController } from './web-controller';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+@injectable()
+export abstract class ApiController extends WebController {
+    protected abstract readonly serviceConfig: ServiceConfiguration;
+
+    public hasPayload(): boolean {
+        return this.context.req.rawBody !== undefined && !isEmpty(this.tryGetPayload<any>());
+    }
+
+    /**
+     * Try parse a JSON string from the HTTP request body.
+     * Will return undefined if parsing was unsuccessful; otherwise object representation of a JSON string.
+     */
+    public tryGetPayload<T>(): T {
+        try {
+            return JSON.parse(this.context.req.rawBody);
+        } catch (error) {
+            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidJsonDocument);
+        }
+
+        return undefined;
+    }
+
+    protected validateRequest(...args: any[]): boolean {
+        if (!this.validateApiVersion() || !this.validateContentType()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected validateContentType(): boolean {
+        if (this.context.req.method !== 'POST' && this.context.req.method !== 'PUT') {
+            return true;
+        }
+
+        if (!this.hasPayload()) {
+            this.context.res = {
+                status: 204, // No Content
+            };
+
+            return false;
+        }
+
+        if (this.context.req.headers === undefined || this.context.req.headers['content-type'] === undefined) {
+            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader);
+
+            return false;
+        }
+
+        if (this.context.req.headers['content-type'] !== 'application/json') {
+            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedContentType);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected validateApiVersion(): boolean {
+        if (this.context.req.query === undefined || this.context.req.query['api-version'] === undefined) {
+            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter);
+
+            return false;
+        }
+
+        if (this.context.req.query['api-version'] !== this.apiVersion && this.context.req.query['api-version'] !== '2.0') {
+            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected async getRestApiConfig(): Promise<RestApiConfig> {
+        return this.serviceConfig.getConfigValue('restApiConfig');
+    }
+}

--- a/packages/service-library/src/web-api/get-global-web-controller-dispatcher.spec.ts
+++ b/packages/service-library/src/web-api/get-global-web-controller-dispatcher.spec.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { IMock, Mock } from 'typemoq';
+import { getGlobalWebControllerDispatcher } from './get-global-web-controller-dispatcher';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock('./web-controller-dispatcher', () => {
+    return {
+        ['WebControllerDispatcher']: class WebControllerDispatcherStub {
+            public startCallCount: number = 0;
+
+            public async start(): Promise<void> {
+                this.startCallCount += 1;
+            }
+        },
+    };
+});
+
+describe(getGlobalWebControllerDispatcher, () => {
+    let containerMock: IMock<Container>;
+
+    beforeEach(() => {
+        containerMock = Mock.ofType(Container);
+    });
+
+    it('does not create more than one instance', async () => {
+        const instance1Promise = getGlobalWebControllerDispatcher(containerMock.object);
+        const instance2Promise = getGlobalWebControllerDispatcher(containerMock.object);
+
+        const instance1 = await instance1Promise;
+        const instance2 = await instance2Promise;
+
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        expect(instance1).toBe(instance2);
+        expect((instance1 as any).startCallCount).toBe(1);
+    });
+});

--- a/packages/service-library/src/web-api/get-global-web-controller-dispatcher.ts
+++ b/packages/service-library/src/web-api/get-global-web-controller-dispatcher.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Container } from 'inversify';
+import { isNil } from 'lodash';
+import { WebControllerDispatcher } from './web-controller-dispatcher';
+
+let globalWebControllerDispatcher: Promise<WebControllerDispatcher>;
+
+export async function getGlobalWebControllerDispatcher(container: Container): Promise<WebControllerDispatcher> {
+    if (isNil(globalWebControllerDispatcher)) {
+        globalWebControllerDispatcher = createWebDispatcher(container);
+    }
+
+    return globalWebControllerDispatcher;
+}
+
+async function createWebDispatcher(container: Container): Promise<WebControllerDispatcher> {
+    const dispatcher = new WebControllerDispatcher(container);
+
+    await dispatcher.start();
+
+    return dispatcher;
+}

--- a/packages/service-library/src/web-api/http-response.spec.ts
+++ b/packages/service-library/src/web-api/http-response.spec.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { HttpResponse } from './http-response';
+import { WebApiErrorCodes } from './web-api-error-codes';
+
+describe(HttpResponse, () => {
+    it('create HTTP error response from web API code', () => {
+        const webApiCode = WebApiErrorCodes.invalidResourceId;
+        const response = HttpResponse.getErrorResponse(webApiCode);
+        expect(response.status).toEqual(webApiCode.statusCode);
+        expect(response.body.error).toEqual(webApiCode.error);
+    });
+});

--- a/packages/service-library/src/web-api/http-response.ts
+++ b/packages/service-library/src/web-api/http-response.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { WebApiErrorCode } from './web-api-error-codes';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class HttpResponse {
+    public static getErrorResponse(webApiErrorCode: WebApiErrorCode): HttpResponse {
+        return {
+            status: webApiErrorCode.statusCode,
+            body: {
+                error: webApiErrorCode.error,
+            },
+        };
+    }
+
+    public status: number;
+
+    public body: any;
+}

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/* eslint-disable @typescript-eslint/no-extraneous-class, @typescript-eslint/naming-convention,no-underscore-dangle,id-blacklist,id-match */
+
+export declare type WebApiErrorCodeName =
+    | 'ResourceNotFound'
+    | 'InvalidResourceId'
+    | 'InvalidJsonDocument'
+    | 'RequestBodyTooLarge'
+    | 'InvalidURL'
+    | 'InternalError'
+    | 'MissingApiVersionQueryParameter'
+    | 'MissingContentTypeHeader'
+    | 'UnsupportedContentType'
+    | 'UnsupportedApiVersion'
+    | 'MalformedBody';
+
+export interface WebApiErrorCode {
+    statusCode: number;
+    error: WebApiError;
+}
+
+export interface WebApiError {
+    // This type is part of the REST API client response.
+    // Ensure compatibility when changing this type.
+    code: WebApiErrorCodeName;
+    codeId: number;
+    message: string;
+}
+
+// Code ID range 4001 - 5999
+export class WebApiErrorCodes {
+    public static resourceNotFound: WebApiErrorCode = {
+        statusCode: 404,
+        error: {
+            code: 'ResourceNotFound',
+            codeId: 4001,
+            message: 'The specified resource does not exist.',
+        },
+    };
+
+    public static invalidResourceId: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidResourceId',
+            codeId: 4002,
+            message: 'The resource ID is not valid.',
+        },
+    };
+
+    public static invalidURL: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidURL',
+            codeId: 4003,
+            message: 'The URL is not valid.',
+        },
+    };
+
+    public static invalidJsonDocument: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidJsonDocument',
+            codeId: 4004,
+            message: 'The specified JSON is not syntactically valid.',
+        },
+    };
+
+    public static missingApiVersionQueryParameter: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'MissingApiVersionQueryParameter',
+            codeId: 4005,
+            message: `A required 'api-version' query parameter was not specified for this request.`,
+        },
+    };
+
+    public static unsupportedApiVersion: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'UnsupportedApiVersion',
+            codeId: 4006,
+            message: `The specified API version is not supported.`,
+        },
+    };
+
+    public static missingContentTypeHeader: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'MissingContentTypeHeader',
+            codeId: 4007,
+            message: `The 'Content-Type' header was not specified.`,
+        },
+    };
+
+    public static unsupportedContentType: WebApiErrorCode = {
+        statusCode: 415,
+        error: {
+            code: 'UnsupportedContentType',
+            codeId: 4008,
+            message: 'The specified request content type is not supported.',
+        },
+    };
+
+    public static requestBodyTooLarge: WebApiErrorCode = {
+        statusCode: 413,
+        error: {
+            code: 'RequestBodyTooLarge',
+            codeId: 4009,
+            message: 'The size of the request body exceeds the maximum size permitted.',
+        },
+    };
+
+    public static malformedRequest: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'MalformedBody',
+            codeId: 4011,
+            message: 'The request body does not match the API schema for the given API version.',
+        },
+    };
+}

--- a/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Context } from '@azure/functions';
+import { Container } from 'inversify';
+import { ContextAwareLogger, loggerTypes } from 'logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { MockableLogger } from '../test-utilities/mockable-logger';
+import { WebController } from './web-controller';
+import { WebControllerDispatcher } from './web-controller-dispatcher';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export class TestableWebController extends WebController {
+    public static readonly handleRequestResult = 'handle-request-result';
+
+    public readonly apiVersion = '1.0';
+
+    public readonly apiName = 'controller-mock-api';
+
+    public requestArgs: any[];
+
+    public async invoke(requestContext: Context, ...args: any[]): Promise<unknown> {
+        this.context = requestContext;
+        this.requestArgs = args;
+
+        return TestableWebController.handleRequestResult;
+    }
+
+    protected validateRequest(...args: any[]): boolean {
+        return true;
+    }
+
+    protected async handleRequest(...args: any[]): Promise<void> {
+        return;
+    }
+}
+
+describe(WebControllerDispatcher, () => {
+    let webControllerDispatcher: WebControllerDispatcher;
+    let containerMock: IMock<Container>;
+    let context: Context;
+    let testableWebController: TestableWebController;
+    let processLifeCycleContainerMock: IMock<Container>;
+    let loggerMock: IMock<MockableLogger>;
+
+    beforeEach(() => {
+        context = <Context>(<unknown>{ bindingDefinitions: {} });
+        loggerMock = Mock.ofType(MockableLogger);
+        testableWebController = new TestableWebController(loggerMock.object);
+
+        containerMock = Mock.ofType(Container);
+        processLifeCycleContainerMock = Mock.ofType(Container);
+
+        containerMock.setup((c) => c.get(TestableWebController)).returns(() => testableWebController);
+        containerMock.setup((c) => c.get(ContextAwareLogger)).returns(() => loggerMock.object);
+    });
+
+    afterEach(() => {
+        loggerMock.verifyAll();
+        containerMock.verifyAll();
+        processLifeCycleContainerMock.verifyAll();
+    });
+
+    it('should invoke controller instance with args', async () => {
+        webControllerDispatcher = new WebControllerDispatcher(processLifeCycleContainerMock.object);
+
+        loggerMock
+            .setup((l) => l.setup())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        await webControllerDispatcher.processRequest(containerMock.object, TestableWebController, context, 1, 'a');
+
+        expect(testableWebController.context).toEqual(context);
+        expect(testableWebController.requestArgs).toEqual([1, 'a']);
+    });
+
+    it('should set base telemetry properties', async () => {
+        const processStub: typeof process = {
+            env: {
+                WEBSITE_INSTANCE_ID: 'server_id',
+            },
+        } as any;
+
+        processLifeCycleContainerMock.setup((c) => c.get(loggerTypes.Process)).returns(() => processStub);
+
+        webControllerDispatcher = new WebControllerDispatcher(processLifeCycleContainerMock.object);
+
+        expect((webControllerDispatcher as any).getTelemetryBaseProperties()).toEqual({
+            source: 'azure-function',
+            serverInstanceId: 'server_id',
+        });
+    });
+
+    it('should do nothing on invoking custom action', async () => {
+        webControllerDispatcher = new WebControllerDispatcher(processLifeCycleContainerMock.object);
+
+        await expect((webControllerDispatcher as any).runCustomAction()).toResolve();
+    });
+
+    it('return result of invoke', async () => {
+        loggerMock
+            .setup((l) => l.setup())
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
+
+        webControllerDispatcher = new WebControllerDispatcher(processLifeCycleContainerMock.object);
+        await expect(webControllerDispatcher.processRequest(containerMock.object, TestableWebController, context)).resolves.toBe(
+            TestableWebController.handleRequestResult,
+        );
+    });
+});

--- a/packages/service-library/src/web-api/web-controller-dispatcher.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Context } from '@azure/functions';
+import { Container } from 'inversify';
+import { BaseTelemetryProperties, ContextAwareLogger, loggerTypes } from 'logger';
+import { ProcessEntryPointBase } from '../process-entry-point-base';
+import { Newable } from './web-api-ioc-types';
+import { WebController } from './web-controller';
+
+export class WebControllerDispatcher extends ProcessEntryPointBase {
+    constructor(private readonly processLifeCycleContainer: Container) {
+        super(processLifeCycleContainer);
+    }
+
+    public async processRequest(
+        container: Container,
+        controllerType: Newable<WebController>,
+        context: Context,
+        ...args: unknown[]
+    ): Promise<unknown> {
+        const logger = container.get(ContextAwareLogger);
+        await logger.setup();
+
+        const controller = container.get(controllerType) as WebController;
+
+        return controller.invoke(context, ...args);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    protected async runCustomAction(container: Container, ...args: unknown[]): Promise<void> {}
+
+    protected getTelemetryBaseProperties(): BaseTelemetryProperties {
+        const currentProcess: typeof process = this.processLifeCycleContainer.get(loggerTypes.Process);
+
+        return {
+            source: 'azure-function',
+            serverInstanceId: currentProcess.env.WEBSITE_INSTANCE_ID,
+        };
+    }
+}

--- a/packages/service-library/src/web-api/web-controller-dispatcher.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.ts
@@ -5,8 +5,10 @@ import { Context } from '@azure/functions';
 import { Container } from 'inversify';
 import { BaseTelemetryProperties, ContextAwareLogger, loggerTypes } from 'logger';
 import { ProcessEntryPointBase } from '../process-entry-point-base';
-import { Newable } from './web-api-ioc-types';
 import { WebController } from './web-controller';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Newable<T> = new (...args: any[]) => T;
 
 export class WebControllerDispatcher extends ProcessEntryPointBase {
     constructor(private readonly processLifeCycleContainer: Container) {

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Context } from '@azure/functions';
+import { System } from 'common';
+import { inject, injectable } from 'inversify';
+import { ContextAwareLogger } from 'logger';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+@injectable()
+export abstract class WebController {
+    public context: Context;
+
+    constructor(@inject(ContextAwareLogger) protected readonly logger: ContextAwareLogger) {}
+
+    public abstract readonly apiVersion: string;
+
+    public abstract readonly apiName: string;
+
+    public async invoke(requestContext: Context, ...args: any[]): Promise<unknown> {
+        this.context = requestContext;
+
+        try {
+            this.logger.setCommonProperties(this.getBaseTelemetryProperties());
+
+            let result: unknown;
+            if (this.validateRequest(...args)) {
+                result = await this.handleRequest(...args);
+            }
+
+            this.setResponseContentTypeHeader();
+
+            return result;
+        } catch (error) {
+            this.logger.logError('Encountered an error while processing HTTP web request.', { error: System.serializeError(error) });
+            throw error;
+        }
+    }
+
+    protected abstract validateRequest(...args: any[]): boolean;
+
+    protected abstract handleRequest(...args: any[]): Promise<unknown>;
+
+    protected getBaseTelemetryProperties(): { [name: string]: string } {
+        return {
+            apiName: this.apiName,
+            apiVersion: this.apiVersion,
+            controller: this.constructor.name,
+            invocationId: this.context.invocationId,
+        };
+    }
+
+    private setResponseContentTypeHeader(): void {
+        if (this.context !== undefined && this.context.res !== undefined) {
+            const jsonContentType = 'application/json; charset=utf-8';
+            if (this.context.res.headers === undefined) {
+                this.context.res.headers = {
+                    'content-type': jsonContentType,
+                    'X-Content-Type-Options': 'nosniff',
+                };
+            } else if (this.context.res.headers['content-type'] === undefined) {
+                this.context.res.headers['content-type'] = jsonContentType;
+                this.context.res.headers['X-Content-Type-Options'] = 'nosniff';
+            }
+        }
+    }
+}

--- a/packages/service-library/tsconfig.json
+++ b/packages/service-library/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,6 +120,11 @@
     universal-user-agent "^6.0.0"
     uuid "^8.3.0"
 
+"@azure/functions@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@azure/functions/-/functions-1.2.3.tgz#65765837e7319eedffbf8a971cb2f78d4e043d54"
+  integrity sha512-dZITbYPNg6ay6ngcCOjRUh1wDhlFITS0zIkqplyH5KfKEAVPooaoaye5mUFnR+WP9WdGRjlNXyl/y2tgWKHcRg==
+
 "@azure/identity@^1.2.4":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@azure/identity/-/identity-1.3.0.tgz#04e816ac4776c3a7d26357412c2621141fd848c6"
@@ -7152,7 +7157,7 @@ jest-jasmine2@^27.0.4:
     pretty-format "^27.0.2"
     throat "^6.0.1"
 
-jest-junit@^12.2.0:
+jest-junit@^12.1.0, jest-junit@^12.2.0:
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.2.0.tgz#cff7f9516e84f8e30f6bdea04cd84db6b095a376"
   integrity sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==
@@ -7626,7 +7631,7 @@ jest-worker@^27.0.2:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.0.4:
+jest@^27.0.3, jest@^27.0.4:
   version "27.0.4"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.0.4.tgz#91d4d564b36bcf93b98dac1ab19f07089e670f53"
   integrity sha512-Px1iKFooXgGSkk1H8dJxxBIrM3tsc5SIuI4kfKYK2J+4rvCvPGr/cXktxh0e9zIPQ5g09kOMNfHQEmusBUf/ZA==
@@ -11155,7 +11160,7 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-jest@^27.0.3:
+ts-jest@^27.0.2, ts-jest@^27.0.3:
   version "27.0.3"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.3.tgz#808492f022296cde19390bb6ad627c8126bf93f8"
   integrity sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==


### PR DESCRIPTION
#### Details

Add base/helper code for the web api from the Accessibility Insights service repo

##### Motivation

This will enable us to reuse the same base code when implementing the REST API for the storage repos

##### Context

Work deferred to future PRs:
- Create data providers to provide access to storage documents
- Add a web-api package and function app implementation for the REST API

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
