### PR TITLE
chore: manually enable container registry access

### DIFF
--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -14,13 +14,11 @@ Usage: $0 -r <resource group> -l <location> -c <cluster name> -d <container regi
 
 function attachContainerRegistry() {
     # grant cluster sp access to container registry
-    principalId=$(az aks show --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --query "identity.principalId" -o tsv)
-    role="acrPull"
+    principalId=$(az aks show --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --query "identityProfile.kubeletidentity.objectId" -o tsv)
+    role="AcrPull"
     containerRegistryId=$(az acr show --resource-group "$resourceGroupName" --name "$containerRegistry" --query id -o tsv)
     scope="--scope $containerRegistryId"
     . "${0%/*}/role-assign-for-sp.sh"
-
-    az aks update --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --attach-acr "$containerRegistry" 1>/dev/null
 }
 
 # Read script arguments
@@ -41,6 +39,5 @@ fi
 
 # Deploy Azure Kubernetes Service
 echo "Deploying Azure Kubernetes Service in resource group $resourceGroupName"
-az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" --enable-managed-identity 1>/dev/null
-
+az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" 1>/dev/null
 attachContainerRegistry

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -39,5 +39,5 @@ fi
 
 # Deploy Azure Kubernetes Service
 echo "Deploying Azure Kubernetes Service in resource group $resourceGroupName"
-az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" 1>/dev/null
+az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" --no-ssh-key 1>/dev/null
 attachContainerRegistry

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -12,6 +12,17 @@ Usage: $0 -r <resource group> -l <location> -c <cluster name> -d <container regi
     exit 1
 }
 
+function attachContainerRegistry() {
+    # grant cluster sp access to container registry
+    principalId=$(az aks show --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --query "identity.principalId" -o tsv)
+    role="acrPull"
+    containerRegistryId=$(az acr show --resource-group "$resourceGroupName" --name "$containerRegistry" --query id -o tsv)
+    scope="--scope $containerRegistryId"
+    . "${0%/*}/role-assign-for-sp.sh"
+
+    az aks update --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --attach-acr "$containerRegistry" 1>/dev/null
+}
+
 # Read script arguments
 while getopts ":r:c:l:d:" option; do
     case $option in
@@ -30,4 +41,6 @@ fi
 
 # Deploy Azure Kubernetes Service
 echo "Deploying Azure Kubernetes Service in resource group $resourceGroupName"
-az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" --attach-acr "$containerRegistry" 1>/dev/null
+az aks create --resource-group "$resourceGroupName" --name "$kubernetesServiceName" --location "$location" --enable-managed-identity 1>/dev/null
+
+attachContainerRegistry

--- a/packages/resource-deployment/scripts/role-assign-for-sp.sh
+++ b/packages/resource-deployment/scripts/role-assign-for-sp.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+set -eo pipefail
+
+# The script will create a new role assignment for a service principal
+
+exitWithUsageInfo() {
+    echo "
+Usage: $0 -r <resource group> -p <service principal id> -g <Azure role name or id> -s <scope at which the role assignment applies to>
+"
+    exit 1
+}
+
+# Read script arguments
+while getopts ":r:p:o:" option; do
+    case $option in
+    r) resourceGroupName=${OPTARG} ;;
+    p) principalId=${OPTARG} ;;
+    g) role=${OPTARG} ;;
+    s) scope=${OPTARG} ;;
+    *) exitWithUsageInfo ;;
+    esac
+done
+
+if [[ -z $resourceGroupName ]] || [[ -z $principalId ]] || [[ -z $role ]] || [[ -z $scope ]]; then
+    exitWithUsageInfo
+fi
+
+grantRoleToResource() {
+    local end=$((SECONDS + 300))
+
+    echo "Create '$role' role assignment for service principal $principalId in $scope"
+    printf " - Running .."
+    while [ $SECONDS -le $end ]; do
+        response=$(az role assignment create --role "$role" --assignee-object-id "$principalId" --assignee-principal-type ServicePrincipal $scope --query "roleDefinitionId") || true
+        if [[ -n $response ]]; then
+            break
+        else
+            printf "."
+        fi
+
+        sleep 5
+    done
+    echo "  ended"
+
+    if [[ -z $response ]]; then
+        echo "Unable to create '$role' role assignment for service principal $principalId in $scope"
+        exit 1
+    fi
+
+    echo "Successfully granted '$role' role for service principal $principalId in $scope"
+}
+
+grantRoleToResource


### PR DESCRIPTION
#### Details

Assign the AcrPull role to the kubernetes cluster to enable container registry access. This has the same effect as using the --attach-acr cli option when creating the cluster.

This PR also adds the --no-ssh-key option to the kubernetes deployment. It is still possible to establish an ssh connection to the nodes afterward.

##### Motivation

The --attach-acr option uses a legacy API that the deployment service principle doesn't have permission to use, so the command fails in deployment. Assigning the role has the same effect, and doesn't cause errors in deployment.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
