### PR TITLE
Create data providers for website repo docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "scripts": {
         "bootstrap": "npx lerna bootstrap",
         "clean": "npx lerna run clean --stream && rimraf dist test-results",
-        "cbuild": "npx syncpack fix-mismatches format --indent '    ' && yarn install && npx lerna run cbuild --stream",
+        "cbuild": "npx syncpack fix-mismatches format --indent \"    \" && yarn install && npx lerna run cbuild --stream",
         "build": "npx lerna run build --stream",
         "test": "npx jest",
         "publish-code-coverage": "npx codecov",

--- a/packages/azure-services/src/ioc-types.ts
+++ b/packages/azure-services/src/ioc-types.ts
@@ -22,8 +22,6 @@ export type CosmosClientProvider = () => Promise<CosmosClient>;
 export type QueueServiceClientProvider = () => Promise<QueueServiceClient>;
 
 export const cosmosContainerClientTypes = {
-    OnDemandScanBatchRequestsCosmosContainerClient: 'onDemandScanBatchRequestsCosmosContainerClient',
-    OnDemandScanRunsCosmosContainerClient: 'onDemandScanRunsCosmosContainerClient',
-    OnDemandScanRequestsCosmosContainerClient: 'onDemandScanRequestsCosmosContainerClient',
-    OnDemandSystemDataCosmosContainerClient: 'onDemandSystemDataCosmosContainerClient',
+    websiteRepoContainerClient: 'websiteRepoContainerClient',
+    scanMetadataRepoContainerClient: 'scanMetadataRepoContainerClient',
 };

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -64,13 +64,8 @@ describe(registerAzureServicesToContainer, () => {
     it('resolves CosmosContainerClient', () => {
         registerAzureServicesToContainer(container);
 
-        verifyCosmosContainerClient(container, cosmosContainerClientTypes.websiteRepoContainerClient, 'onDemandScanner', 'scanRequests');
-        verifyCosmosContainerClient(
-            container,
-            cosmosContainerClientTypes.scanMetadataRepoContainerClient,
-            'onDemandScanner',
-            'scanBatchRequests',
-        );
+        verifyCosmosContainerClient(container, cosmosContainerClientTypes.websiteRepoContainerClient, 'WebInsights', 'websiteData');
+        verifyCosmosContainerClient(container, cosmosContainerClientTypes.scanMetadataRepoContainerClient, 'WebInsights', 'scanMetadata');
     });
 
     describe('BlobServiceClientProvider', () => {

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -64,30 +64,12 @@ describe(registerAzureServicesToContainer, () => {
     it('resolves CosmosContainerClient', () => {
         registerAzureServicesToContainer(container);
 
+        verifyCosmosContainerClient(container, cosmosContainerClientTypes.websiteRepoContainerClient, 'onDemandScanner', 'scanRequests');
         verifyCosmosContainerClient(
             container,
-            cosmosContainerClientTypes.OnDemandScanRequestsCosmosContainerClient,
-            'onDemandScanner',
-            'scanRequests',
-        );
-        verifyCosmosContainerClient(
-            container,
-            cosmosContainerClientTypes.OnDemandScanBatchRequestsCosmosContainerClient,
+            cosmosContainerClientTypes.scanMetadataRepoContainerClient,
             'onDemandScanner',
             'scanBatchRequests',
-        );
-        verifyCosmosContainerClient(
-            container,
-            cosmosContainerClientTypes.OnDemandScanRequestsCosmosContainerClient,
-            'onDemandScanner',
-            'scanRequests',
-        );
-
-        verifyCosmosContainerClient(
-            container,
-            cosmosContainerClientTypes.OnDemandScanRunsCosmosContainerClient,
-            'onDemandScanner',
-            'scanRuns',
         );
     });
 

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -47,20 +47,12 @@ export function registerAzureServicesToContainer(
 
     setupSingletonQueueServiceClientProvider(container);
 
-    container.bind(cosmosContainerClientTypes.OnDemandScanBatchRequestsCosmosContainerClient).toDynamicValue((context) => {
-        return createCosmosContainerClient(context.container, 'onDemandScanner', 'scanBatchRequests');
+    container.bind(cosmosContainerClientTypes.websiteRepoContainerClient).toDynamicValue((context) => {
+        return createCosmosContainerClient(context.container, 'WebInsights', 'websiteData');
     });
 
-    container.bind(cosmosContainerClientTypes.OnDemandScanRunsCosmosContainerClient).toDynamicValue((context) => {
-        return createCosmosContainerClient(context.container, 'onDemandScanner', 'scanRuns');
-    });
-
-    container.bind(cosmosContainerClientTypes.OnDemandScanRequestsCosmosContainerClient).toDynamicValue((context) => {
-        return createCosmosContainerClient(context.container, 'onDemandScanner', 'scanRequests');
-    });
-
-    container.bind(cosmosContainerClientTypes.OnDemandSystemDataCosmosContainerClient).toDynamicValue((context) => {
-        return createCosmosContainerClient(context.container, 'onDemandScanner', 'systemData');
+    container.bind(cosmosContainerClientTypes.scanMetadataRepoContainerClient).toDynamicValue((context) => {
+        return createCosmosContainerClient(context.container, 'WebInsights', 'scanMetadata');
     });
 
     container.bind(iocTypeNames.CredentialType).toConstantValue(credentialType);

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -33,6 +33,7 @@
         "typescript": "^4.3.3"
     },
     "dependencies": {
+        "@azure/cosmos": "^3.11.5",
         "@azure/functions": "^1.2.3",
         "azure-services": "1.0.0",
         "common": "^1.0.0",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -34,11 +34,13 @@
     },
     "dependencies": {
         "@azure/functions": "^1.2.3",
+        "azure-services": "1.0.0",
         "common": "^1.0.0",
         "dotenv": "^10.0.0",
         "inversify": "^5.1.1",
         "lodash": "^4.17.21",
         "logger": "1.0.0",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": "^0.1.13",
+        "storage-documents": "1.0.0"
     }
 }

--- a/packages/service-library/src/data-providers/cosmos-query-results-iterable.spec.ts
+++ b/packages/service-library/src/data-providers/cosmos-query-results-iterable.spec.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+import { IMock, It, Mock } from 'typemoq';
+import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
+import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
+
+type TestDocument = {
+    name: string;
+};
+
+describe(CosmosQueryResultsIterable, () => {
+    const query = 'test query';
+    const testDocuments: TestDocument[] = [{ name: 'test document 1' }, { name: 'test document 2' }, { name: 'test document 3' }];
+    let cosmosContainerClientMock: IMock<CosmosContainerClient>;
+
+    let queryResults: CosmosQueryResultsIterable<TestDocument>;
+
+    beforeEach(() => {
+        cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
+        queryResults = getCosmosQueryResultsIterable(cosmosContainerClientMock.object, query);
+    });
+
+    it('factory returns an AsyncIterable', () => {
+        expect(getCosmosQueryResultsIterable(cosmosContainerClientMock.object, query)).toHaveProperty([Symbol.asyncIterator]);
+    });
+
+    it('Throws if the query fails', () => {
+        const response: CosmosOperationResponse<TestDocument[]> = { statusCode: 400 };
+        cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny(), It.isAny())).returns(async () => response);
+        const iterator = queryResults[Symbol.asyncIterator]();
+
+        expect(iterator.next()).rejects.toThrow();
+    });
+
+    it('Returns all items from query', async () => {
+        const response: CosmosOperationResponse<TestDocument[]> = {
+            statusCode: 200,
+            item: testDocuments,
+        };
+
+        const results = [];
+        cosmosContainerClientMock.setup((c) => c.queryDocuments(query, undefined)).returns(async () => response);
+
+        for await (const item of queryResults) {
+            results.push(item);
+        }
+
+        expect(results).toEqual(testDocuments);
+    });
+
+    it('Returns all items from paginated results', async () => {
+        const continuationToken = 'continuation token';
+        const splitIndex = 1;
+        const response1: CosmosOperationResponse<TestDocument[]> = {
+            statusCode: 200,
+            item: testDocuments.slice(0, splitIndex),
+            continuationToken: continuationToken,
+        };
+        const response2: CosmosOperationResponse<TestDocument[]> = {
+            statusCode: 200,
+            item: testDocuments.slice(splitIndex, testDocuments.length),
+        };
+
+        const results = [];
+        cosmosContainerClientMock.setup((c) => c.queryDocuments(query, undefined)).returns(async () => response1);
+        cosmosContainerClientMock.setup((c) => c.queryDocuments(query, continuationToken)).returns(async () => response2);
+
+        for await (const item of queryResults) {
+            results.push(item);
+        }
+
+        expect(results).toEqual(testDocuments);
+    });
+});

--- a/packages/service-library/src/data-providers/cosmos-query-results-iterable.ts
+++ b/packages/service-library/src/data-providers/cosmos-query-results-iterable.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { client, CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
+import { SqlQuerySpec } from '@azure/cosmos';
+import _ from 'lodash';
+
+export class CosmosQueryResultsIterable<T> implements AsyncIterable<T> {
+    constructor(private readonly cosmosContainerClient: CosmosContainerClient, private readonly query: string | SqlQuerySpec) {}
+
+    public [Symbol.asyncIterator](): AsyncIterator<T> {
+        return this.queryCosmosDbGenerator();
+    }
+
+    private async *queryCosmosDbGenerator(): AsyncGenerator<T, unknown, undefined> {
+        let continuationToken;
+        do {
+            const response: CosmosOperationResponse<T[]> = await this.cosmosContainerClient.queryDocuments<T>(
+                this.query,
+                continuationToken,
+            );
+            client.ensureSuccessStatusCode(response);
+            continuationToken = response.continuationToken;
+            yield* response.item;
+        } while (continuationToken !== undefined);
+
+        return undefined;
+    }
+}
+
+export function getCosmosQueryResultsIterable<T>(
+    cosmosContainerClient: CosmosContainerClient,
+    query: string | SqlQuerySpec,
+): CosmosQueryResultsIterable<T> {
+    return new CosmosQueryResultsIterable<T>(cosmosContainerClient, query);
+}

--- a/packages/service-library/src/data-providers/page-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { Page } from 'storage-documents';
+import { ItemType, Page } from 'storage-documents';
 import _ from 'lodash';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { PageProvider } from './page-provider';
@@ -20,7 +20,7 @@ describe(PageProvider, () => {
         id: pageId,
         websiteId: websiteId,
         url: url,
-        itemType: 'page',
+        itemType: ItemType.page,
         partitionKey: partitionKey,
     };
     let cosmosContainerClientMock: IMock<CosmosContainerClient>;
@@ -33,7 +33,7 @@ describe(PageProvider, () => {
         cosmosContainerClientMock = Mock.ofType(CosmosContainerClient, MockBehavior.Strict);
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
         partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
-        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument('page', pageId)).returns(() => partitionKey);
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.page, pageId)).returns(() => partitionKey);
 
         testSubject = new PageProvider(cosmosContainerClientMock.object, guidGeneratorMock.object, partitionKeyFactoryMock.object);
     });

--- a/packages/service-library/src/data-providers/page-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-provider.spec.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
+import { GuidGenerator } from 'common';
+import { Page } from 'storage-documents';
+import _ from 'lodash';
+import { PartitionKeyFactory } from '../factories/partition-key-factory';
+import { PageProvider } from './page-provider';
+
+describe(PageProvider, () => {
+    const websiteId = 'website id';
+    const pageId = 'page id';
+    const url = 'url';
+    const partitionKey = 'partition key';
+    const pageDoc: Page = {
+        id: pageId,
+        websiteId: websiteId,
+        url: url,
+        itemType: 'page',
+        partitionKey: partitionKey,
+    };
+    let cosmosContainerClientMock: IMock<CosmosContainerClient>;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+    let partitionKeyFactoryMock: IMock<PartitionKeyFactory>;
+
+    let testSubject: PageProvider;
+
+    beforeEach(() => {
+        cosmosContainerClientMock = Mock.ofType(CosmosContainerClient, MockBehavior.Strict);
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument('page', pageId)).returns(() => partitionKey);
+
+        testSubject = new PageProvider(cosmosContainerClientMock.object, guidGeneratorMock.object, partitionKeyFactoryMock.object);
+    });
+
+    afterEach(() => {
+        guidGeneratorMock.verifyAll();
+        cosmosContainerClientMock.verifyAll();
+        partitionKeyFactoryMock.verifyAll();
+    });
+
+    describe('createPage', () => {
+        it('creates page doc', async () => {
+            guidGeneratorMock.setup((g) => g.createGuidFromBaseGuid(websiteId)).returns(() => pageId);
+            cosmosContainerClientMock.setup((c) => c.writeDocument(pageDoc)).verifiable();
+
+            await testSubject.createPageForWebsite(url, websiteId);
+        });
+    });
+
+    describe('updatePage', () => {
+        it('throws if no id', () => {
+            const pageData: Partial<Page> = {
+                url: url,
+            };
+
+            expect(testSubject.updatePage(pageData)).rejects.toThrow();
+        });
+
+        it('updates doc with normalized properties', async () => {
+            const updatedPageData: Partial<Page> = {
+                lastScanDate: new Date(0, 1, 2, 3),
+                id: pageId,
+            };
+            const updatedPageDoc = {
+                itemType: 'page',
+                partitionKey: partitionKey,
+                ...updatedPageData,
+            };
+
+            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedPageDoc)).verifiable();
+
+            await testSubject.updatePage(updatedPageData);
+        });
+    });
+
+    describe('readPage', () => {
+        it('reads page with id', async () => {
+            const response = {
+                statusCode: 200,
+                item: pageDoc,
+            } as CosmosOperationResponse<Page>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageId, partitionKey))
+                .returns(async () => response)
+                .verifiable();
+
+            const actualPage = await testSubject.readPage(pageId);
+
+            expect(actualPage).toBe(pageDoc);
+        });
+
+        it('throws if unsuccessful status code', async () => {
+            const response = {
+                statusCode: 404,
+            } as CosmosOperationResponse<Page>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageId, partitionKey))
+                .returns(async () => response)
+                .verifiable();
+
+            expect(testSubject.readPage(pageId)).rejects.toThrow();
+        });
+    });
+
+    describe('readAllPagesForWebsite', () => {
+        const expectedPagesList = [{ id: 'page id 1' }, { id: 'page id 2' }, { id: 'page id 3' }] as Page[];
+
+        it('throws if unsuccessful status code', () => {
+            const response = {
+                statusCode: 404,
+            } as CosmosOperationResponse<Page[]>;
+            cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny(), It.isAny())).returns(async () => response);
+
+            expect(testSubject.readAllPagesForWebsite(websiteId)).rejects.toThrow();
+        });
+
+        it('with no continuation token', async () => {
+            const response = {
+                statusCode: 200,
+                item: expectedPagesList,
+            } as CosmosOperationResponse<Page[]>;
+            cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny(), It.isAny())).returns(async () => response);
+
+            const actualPages = await testSubject.readAllPagesForWebsite(websiteId);
+
+            expect(actualPages).toEqual(expectedPagesList);
+        });
+
+        it('with continuation token', async () => {
+            const continuationToken = 'continuation token';
+            const response1 = {
+                statusCode: 200,
+                item: _.slice(expectedPagesList, 0, 1),
+                continuationToken: continuationToken,
+            } as CosmosOperationResponse<Page[]>;
+            const response2 = {
+                statusCode: 200,
+                item: _.slice(expectedPagesList, 1, expectedPagesList.length),
+            } as CosmosOperationResponse<Page[]>;
+
+            cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny(), undefined)).returns(async (query, contToken) => response1);
+            cosmosContainerClientMock
+                .setup((c) => c.queryDocuments(It.isAny(), continuationToken))
+                .returns(async (query, contToken) => response2);
+
+            const actualPages = await testSubject.readAllPagesForWebsite(websiteId);
+
+            expect(actualPages).toEqual(expectedPagesList);
+        });
+    });
+});

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { client, CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
+import { inject, injectable } from 'inversify';
+import { Page } from 'storage-documents';
+import { GuidGenerator } from 'common';
+import _ from 'lodash';
+import { PartitionKeyFactory } from '../factories/partition-key-factory';
+
+@injectable()
+export class PageProvider {
+    public constructor(
+        @inject(cosmosContainerClientTypes.websiteRepoContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        @inject(PartitionKeyFactory) private readonly partitionKeyFactory: PartitionKeyFactory,
+    ) {}
+
+    public async createPageForWebsite(pageUrl: string, websiteId: string): Promise<void> {
+        const page = this.normalizeDbDocument({
+            id: this.guidGenerator.createGuidFromBaseGuid(websiteId),
+            websiteId: websiteId,
+            url: pageUrl,
+        });
+        await this.cosmosContainerClient.writeDocument(page);
+    }
+
+    public async updatePage(page: Partial<Page>): Promise<void> {
+        await this.cosmosContainerClient.mergeOrWriteDocument(this.normalizeDbDocument(page));
+    }
+
+    public async readPage(id: string): Promise<Page> {
+        const response = await this.cosmosContainerClient.readDocument<Page>(id, this.getPagePartitionKey(id));
+        client.ensureSuccessStatusCode(response);
+
+        return response.item;
+    }
+
+    public async readAllPagesForWebsite(websiteId: string): Promise<Partial<Page>[]> {
+        const partitionKey = this.getPagePartitionKey(websiteId);
+
+        const query = {
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType',
+            parameters: [
+                {
+                    name: '@websiteId',
+                    value: websiteId,
+                },
+                {
+                    name: '@partitionKey',
+                    value: partitionKey,
+                },
+                {
+                    name: '@itemType',
+                    value: 'page',
+                },
+            ],
+        };
+
+        const pageLists: Page[][] = [];
+        let continuationToken;
+        do {
+            const response = (await this.cosmosContainerClient.queryDocuments<Page>(query, continuationToken)) as CosmosOperationResponse<
+                Page[]
+            >;
+
+            client.ensureSuccessStatusCode(response);
+            continuationToken = response.continuationToken;
+            pageLists.push(response.item);
+        } while (continuationToken !== undefined);
+
+        return _.flatten(pageLists);
+    }
+
+    private getPagePartitionKey(pageOrWebsiteId: string): string {
+        return this.partitionKeyFactory.createPartitionKeyForDocument('page', pageOrWebsiteId);
+    }
+
+    private normalizeDbDocument(page: Partial<Page>): Partial<Page> {
+        if (page.id === undefined) {
+            throw new Error('Page document has no associated id');
+        }
+
+        return {
+            itemType: 'page',
+            partitionKey: this.getPagePartitionKey(page.id),
+            ...page,
+        };
+    }
+}

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { Page } from 'storage-documents';
+import { ItemType, Page } from 'storage-documents';
 import { GuidGenerator } from 'common';
 import _ from 'lodash';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
@@ -73,7 +73,7 @@ export class PageProvider {
     }
 
     private getPagePartitionKey(pageOrWebsiteId: string): string {
-        return this.partitionKeyFactory.createPartitionKeyForDocument('page', pageOrWebsiteId);
+        return this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.page, pageOrWebsiteId);
     }
 
     private normalizeDbDocument(page: Partial<Page>): Partial<Page> {
@@ -82,7 +82,7 @@ export class PageProvider {
         }
 
         return {
-            itemType: 'page',
+            itemType: ItemType.page,
             partitionKey: this.getPagePartitionKey(page.id),
             ...page,
         };

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -87,6 +87,7 @@ describe(WebsiteProvider, () => {
                 name: 'test website',
             } as Website;
             const response = {
+                statusCode: 200,
                 item: expectedWebsite,
             } as CosmosOperationResponse<Website>;
             cosmosContainerClientMock
@@ -97,6 +98,18 @@ describe(WebsiteProvider, () => {
             const actualWebsite = await testSubject.readWebsite(websiteId);
 
             expect(actualWebsite).toBe(expectedWebsite);
+        });
+
+        it('throws if unsuccessful status code', async () => {
+            const response = {
+                statusCode: 404,
+            } as CosmosOperationResponse<Website>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(websiteId, PartitionKey.websiteDocuments))
+                .returns(async () => response)
+                .verifiable();
+
+            expect(testSubject.readWebsite(websiteId)).rejects.toThrow();
         });
     });
 

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { DocumentDataOnly, PartitionKey, Website } from 'storage-documents';
+import { DocumentDataOnly, ItemType, PartitionKey, Website } from 'storage-documents';
 import { WebsiteProvider } from './website-provider';
 
 describe(WebsiteProvider, () => {
@@ -116,7 +116,7 @@ describe(WebsiteProvider, () => {
     function getNormalizedDocument(website: Partial<Website>): Partial<Website> {
         return {
             id: websiteId,
-            itemType: 'website',
+            itemType: ItemType.website,
             partitionKey: PartitionKey.websiteDocuments,
             ...website,
         };

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { IMock, Mock, MockBehavior } from 'typemoq';
+import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
+import { GuidGenerator } from 'common';
+import { DocumentDataOnly, PartitionKey, Website } from 'storage-documents';
+import { WebsiteProvider } from './website-provider';
+
+describe(WebsiteProvider, () => {
+    const websiteId = 'website id';
+    let cosmosContainerClientMock: IMock<CosmosContainerClient>;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+
+    let testSubject: WebsiteProvider;
+
+    beforeEach(() => {
+        cosmosContainerClientMock = Mock.ofType(CosmosContainerClient, MockBehavior.Strict);
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+
+        testSubject = new WebsiteProvider(cosmosContainerClientMock.object, guidGeneratorMock.object);
+    });
+
+    afterEach(() => {
+        guidGeneratorMock.verifyAll();
+        cosmosContainerClientMock.verifyAll();
+    });
+
+    describe('createWebsite', () => {
+        it('generates id and adds additional document properties', async () => {
+            const websiteData = {
+                name: 'test website',
+            } as DocumentDataOnly<Website>;
+
+            const expectedDocument = getNormalizedDocument(websiteData);
+
+            guidGeneratorMock
+                .setup((g) => g.createGuid())
+                .returns(() => websiteId)
+                .verifiable();
+            cosmosContainerClientMock.setup((c) => c.writeDocument(expectedDocument)).verifiable();
+
+            await testSubject.createWebsite(websiteData);
+        });
+
+        it('does not overwrite existing id', async () => {
+            const websiteData = {
+                name: 'test website',
+                id: websiteId,
+            } as DocumentDataOnly<Website>;
+
+            const expectedDocument = getNormalizedDocument(websiteData);
+
+            cosmosContainerClientMock.setup((c) => c.writeDocument(expectedDocument)).verifiable();
+
+            await testSubject.createWebsite(websiteData);
+        });
+    });
+
+    describe('updateWebsite', () => {
+        it('throws if no id', () => {
+            const websiteData: Partial<Website> = {
+                name: 'test website',
+            };
+
+            expect(testSubject.updateWebsite(websiteData)).rejects.toThrow();
+        });
+
+        it('updates doc with normalized properties', async () => {
+            const websiteData: Partial<Website> = {
+                name: 'test website',
+                id: websiteId,
+            };
+            const expectedDocument = getNormalizedDocument(websiteData);
+
+            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(expectedDocument)).verifiable();
+
+            await testSubject.updateWebsite(websiteData);
+        });
+    });
+
+    describe('readWebsite', () => {
+        it('reads website with id', async () => {
+            const expectedWebsite = {
+                name: 'test website',
+            } as Website;
+            const response = {
+                item: expectedWebsite,
+            } as CosmosOperationResponse<Website>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(websiteId, PartitionKey.websiteDocuments))
+                .returns(async () => response)
+                .verifiable();
+
+            const actualWebsite = await testSubject.readWebsite(websiteId);
+
+            expect(actualWebsite).toBe(expectedWebsite);
+        });
+    });
+
+    function getNormalizedDocument(website: Partial<Website>): Partial<Website> {
+        return {
+            id: websiteId,
+            itemType: 'website',
+            partitionKey: PartitionKey.websiteDocuments,
+            ...website,
+        };
+    }
+});

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { DocumentDataOnly, PartitionKey, Website } from 'storage-documents';
+import { DocumentDataOnly, ItemType, PartitionKey, Website } from 'storage-documents';
 import { GuidGenerator } from 'common';
 
 @injectable()
@@ -37,7 +37,7 @@ export class WebsiteProvider {
 
         return {
             id: id,
-            itemType: 'website',
+            itemType: ItemType.website,
             partitionKey: PartitionKey.websiteDocuments,
             ...website,
         };

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
+import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import { DocumentDataOnly, PartitionKey, Website } from 'storage-documents';
 import { GuidGenerator } from 'common';
@@ -24,7 +24,10 @@ export class WebsiteProvider {
     }
 
     public async readWebsite(id: string): Promise<Website> {
-        return (await this.cosmosContainerClient.readDocument<Website>(id, PartitionKey.websiteDocuments)).item;
+        const response = await this.cosmosContainerClient.readDocument<Website>(id, PartitionKey.websiteDocuments);
+        client.ensureSuccessStatusCode(response);
+
+        return response.item;
     }
 
     private normalizeDbDocument(website: Partial<Website>, id?: string): Partial<Website> {

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
+import { inject, injectable } from 'inversify';
+import { DocumentDataOnly, PartitionKey, Website } from 'storage-documents';
+import { GuidGenerator } from 'common';
+
+@injectable()
+export class WebsiteProvider {
+    public constructor(
+        @inject(cosmosContainerClientTypes.websiteRepoContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+    ) {}
+
+    public async createWebsite(websiteData: DocumentDataOnly<Website>): Promise<void> {
+        const websiteDoc = this.normalizeDbDocument(websiteData, this.guidGenerator.createGuid());
+        await this.cosmosContainerClient.writeDocument(websiteDoc);
+    }
+
+    public async updateWebsite(website: Partial<Website>): Promise<void> {
+        const websiteDoc = this.normalizeDbDocument(website);
+        await this.cosmosContainerClient.mergeOrWriteDocument(websiteDoc);
+    }
+
+    public async readWebsite(id: string): Promise<Website> {
+        return (await this.cosmosContainerClient.readDocument<Website>(id, PartitionKey.websiteDocuments)).item;
+    }
+
+    private normalizeDbDocument(website: Partial<Website>, id?: string): Partial<Website> {
+        if (id === undefined && website.id === undefined) {
+            throw new Error('Website document has no associated id');
+        }
+
+        return {
+            id: id,
+            itemType: 'website',
+            partitionKey: PartitionKey.websiteDocuments,
+            ...website,
+        };
+    }
+}

--- a/packages/service-library/src/factories/partition-key-factory.spec.ts
+++ b/packages/service-library/src/factories/partition-key-factory.spec.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { GuidGenerator, HashGenerator } from 'common';
+import { IMock, Mock } from 'typemoq';
+import { PartitionKeyFactory } from './partition-key-factory';
+
+let hashGeneratorMock: IMock<HashGenerator>;
+let guidGeneratorMock: IMock<GuidGenerator>;
+let partitionKeyFactory: PartitionKeyFactory;
+
+beforeEach(() => {
+    hashGeneratorMock = Mock.ofType(HashGenerator);
+    guidGeneratorMock = Mock.ofType(GuidGenerator);
+    partitionKeyFactory = new PartitionKeyFactory(hashGeneratorMock.object, guidGeneratorMock.object);
+});
+
+afterEach(() => {
+    guidGeneratorMock.verifyAll();
+    hashGeneratorMock.verifyAll();
+});
+
+describe(PartitionKeyFactory, () => {
+    it('create partition key for the storage document', () => {
+        const documentId = 'doc1';
+        const partitionKeyResult = 'itemType-10';
+        setupGenerators('page', documentId, partitionKeyResult);
+        const partitionKey = partitionKeyFactory.createPartitionKeyForDocument('page', documentId);
+        expect(partitionKey).toEqual(partitionKeyResult);
+    });
+});
+
+function setupGenerators(partitionKeyPrefix: string, documentId: string, partitionKey: string): void {
+    const scanIdNode = `${documentId}-node`;
+    guidGeneratorMock
+        .setup((g) => g.getGuidNode(documentId))
+        .returns(() => scanIdNode)
+        .verifiable();
+
+    hashGeneratorMock
+        .setup((h) => h.getDbHashBucket(partitionKeyPrefix, scanIdNode))
+        .returns(() => partitionKey)
+        .verifiable();
+}

--- a/packages/service-library/src/factories/partition-key-factory.spec.ts
+++ b/packages/service-library/src/factories/partition-key-factory.spec.ts
@@ -5,6 +5,7 @@ import 'reflect-metadata';
 
 import { GuidGenerator, HashGenerator } from 'common';
 import { IMock, Mock } from 'typemoq';
+import { ItemType } from 'storage-documents';
 import { PartitionKeyFactory } from './partition-key-factory';
 
 let hashGeneratorMock: IMock<HashGenerator>;
@@ -27,7 +28,7 @@ describe(PartitionKeyFactory, () => {
         const documentId = 'doc1';
         const partitionKeyResult = 'itemType-10';
         setupGenerators('page', documentId, partitionKeyResult);
-        const partitionKey = partitionKeyFactory.createPartitionKeyForDocument('page', documentId);
+        const partitionKey = partitionKeyFactory.createPartitionKeyForDocument(ItemType.page, documentId);
         expect(partitionKey).toEqual(partitionKeyResult);
     });
 });

--- a/packages/service-library/src/factories/partition-key-factory.ts
+++ b/packages/service-library/src/factories/partition-key-factory.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GuidGenerator, HashGenerator } from 'common';
+import { inject, injectable } from 'inversify';
+import { ItemType } from 'storage-documents';
+
+@injectable()
+export class PartitionKeyFactory {
+    constructor(
+        @inject(HashGenerator) private readonly hashGenerator: HashGenerator,
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+    ) {}
+
+    public createPartitionKeyForDocument(documentType: ItemType, documentGuid: string): string {
+        const node = this.guidGenerator.getGuidNode(documentGuid);
+
+        return this.hashGenerator.getDbHashBucket(documentType, node);
+    }
+}

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+export { ItemType } from './item-type';
 export { PageScan } from './page-scan';
 export { Page } from './page';
+export { PartitionKey } from './partition-key';
 export { ReportData, PageReportFormat } from './report-data';
 export { WebsiteScan } from './website-scan';
 export { Website } from './website';
 export { ScanType, ScanStatus } from './scan-types';
-export { StorageDocument } from './storage-document';
+export { DocumentDataOnly, StorageDocument } from './storage-document';

--- a/packages/storage-documents/src/item-type.ts
+++ b/packages/storage-documents/src/item-type.ts
@@ -1,4 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export type ItemType = 'website' | 'page' | 'websiteScan' | 'pageScan';
+export enum ItemType {
+    website = 'website',
+    page = 'page',
+    websiteScan = 'websiteScan',
+    pageScan = 'page',
+}

--- a/packages/storage-documents/src/item-type.ts
+++ b/packages/storage-documents/src/item-type.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type ItemType = 'website' | 'page' | 'websiteScan' | 'pageScan';

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ItemType } from './item-type';
 import { ReportData } from './report-data';
 import { ScanStatus } from './scan-types';
 import { StorageDocument } from './storage-document';
@@ -10,7 +11,7 @@ import { StorageDocument } from './storage-document';
  * Must have a unique combination of pageId and websiteScanId.
  */
 export interface PageScan extends StorageDocument {
-    itemType: 'pageScan';
+    itemType: ItemType.pageScan;
     websiteScanId: string; // maps to a WebsiteScan document
     pageId: string; // maps to a Page document
     priority: number;

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -10,6 +10,7 @@ import { StorageDocument } from './storage-document';
  * Must have a unique combination of pageId and websiteScanId.
  */
 export interface PageScan extends StorageDocument {
+    itemType: 'pageScan';
     websiteScanId: string; // maps to a WebsiteScan document
     pageId: string; // maps to a Page document
     priority: number;

--- a/packages/storage-documents/src/page.ts
+++ b/packages/storage-documents/src/page.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ItemType } from './item-type';
 import { StorageDocument } from './storage-document';
 
 export interface Page extends StorageDocument {
-    itemType: 'page';
+    itemType: ItemType.page;
     websiteId: string; // maps to a Website document
     url: string;
     lastScanDate?: Date;

--- a/packages/storage-documents/src/page.ts
+++ b/packages/storage-documents/src/page.ts
@@ -4,6 +4,7 @@
 import { StorageDocument } from './storage-document';
 
 export interface Page extends StorageDocument {
+    itemType: 'page';
     websiteId: string; // maps to a Website document
     url: string;
     lastScanDate?: Date;

--- a/packages/storage-documents/src/partition-key.ts
+++ b/packages/storage-documents/src/partition-key.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export enum PartitionKey {
+    websiteDocuments = 'websiteDocuments',
+    pageDocuments = 'pageDocuments',
+    websiteScanDocuments = 'websiteScanDocuments',
+    pageScanDocuments = 'pageScanDocuments',
+}

--- a/packages/storage-documents/src/partition-key.ts
+++ b/packages/storage-documents/src/partition-key.ts
@@ -3,7 +3,4 @@
 
 export enum PartitionKey {
     websiteDocuments = 'websiteDocuments',
-    pageDocuments = 'pageDocuments',
-    websiteScanDocuments = 'websiteScanDocuments',
-    pageScanDocuments = 'pageScanDocuments',
 }

--- a/packages/storage-documents/src/storage-document.ts
+++ b/packages/storage-documents/src/storage-document.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ItemType } from './item-type';
+
+export type DocumentDataOnly<T> = Omit<T, keyof StorageDocument> & Partial<StorageDocument>;
+
 export interface StorageDocument {
     /** Required.
      * Unique name that identifies the item, that is, no two items share the same ID within a database.
@@ -11,7 +15,7 @@ export interface StorageDocument {
     /** Required.
      * Name that identifies the item type.
      */
-    itemType: string;
+    itemType: ItemType;
 
     /**
      * Partition key used to store the document.

--- a/packages/storage-documents/src/storage-document.ts
+++ b/packages/storage-documents/src/storage-document.ts
@@ -3,7 +3,7 @@
 
 import { ItemType } from './item-type';
 
-export type DocumentDataOnly<T> = Omit<T, keyof StorageDocument> & Partial<StorageDocument>;
+export type DocumentDataOnly<T> = Omit<T, keyof StorageDocument> & Partial<StorageDocument> & Partial<T>;
 
 export interface StorageDocument {
     /** Required.

--- a/packages/storage-documents/src/storage-document.ts
+++ b/packages/storage-documents/src/storage-document.ts
@@ -3,7 +3,7 @@
 
 import { ItemType } from './item-type';
 
-export type DocumentDataOnly<T> = Omit<T, keyof StorageDocument> & Partial<StorageDocument> & Partial<T>;
+export type DocumentDataOnly<T extends StorageDocument> = Omit<T, keyof StorageDocument> & Partial<T>;
 
 export interface StorageDocument {
     /** Required.

--- a/packages/storage-documents/src/website-scan.ts
+++ b/packages/storage-documents/src/website-scan.ts
@@ -9,6 +9,7 @@ import { StorageDocument } from './storage-document';
  * Represents a scan/crawl of a full website for one scan type
  */
 export interface WebsiteScan extends StorageDocument {
+    itemType: 'websiteScan';
     websiteId: string; // Maps to a Website
     scanType: ScanType;
     scanFrequency: number;

--- a/packages/storage-documents/src/website-scan.ts
+++ b/packages/storage-documents/src/website-scan.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ItemType } from './item-type';
 import { ReportData } from './report-data';
 import { ScanStatus, ScanType } from './scan-types';
 import { StorageDocument } from './storage-document';
@@ -9,7 +10,7 @@ import { StorageDocument } from './storage-document';
  * Represents a scan/crawl of a full website for one scan type
  */
 export interface WebsiteScan extends StorageDocument {
-    itemType: 'websiteScan';
+    itemType: ItemType.websiteScan;
     websiteId: string; // Maps to a Website
     scanType: ScanType;
     scanFrequency: number;

--- a/packages/storage-documents/src/website.ts
+++ b/packages/storage-documents/src/website.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ItemType } from './item-type';
 import { ScanType } from './scan-types';
 import { StorageDocument } from './storage-document';
 
 export interface Website extends StorageDocument {
     name: string;
-    itemType: 'website';
+    itemType: ItemType.website;
     baseUrl: string;
     priority: number;
     discoveryPatterns: string[];

--- a/packages/storage-documents/src/website.ts
+++ b/packages/storage-documents/src/website.ts
@@ -6,6 +6,7 @@ import { StorageDocument } from './storage-document';
 
 export interface Website extends StorageDocument {
     name: string;
+    itemType: 'website';
     baseUrl: string;
     priority: number;
     discoveryPatterns: string[];


### PR DESCRIPTION
#### Details

Adds data providers for Website and Page documents

##### Motivation

Enable access to the storage documents in the web API and scan tasks

##### Context

Data providers for WebsiteScanMetadata and PageMetadata will be added in a separate PR

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
