### PR TITLE
Scan metadata providers

### DIFF
--- a/packages/common/src/ciphers/hash-generator.spec.ts
+++ b/packages/common/src/ciphers/hash-generator.spec.ts
@@ -35,17 +35,10 @@ describe('HashGenerator', () => {
         expect(bucket).toEqual('bucket-425');
     });
 
-    it('generate WebsiteScanResultDocumentId', () => {
+    it('generate pageScanDocumentId', () => {
         hashGenerator = new HashGenerator(SHA);
-        const id = hashGenerator.getWebsiteScanResultDocumentId('baseUrl', 'scanGroupId');
-        const expectedId = hashGenerator.generateBase64Hash('baseUrl', 'scanGroupId');
-        expect(id).toEqual(expectedId);
-    });
-
-    it('generate WebsiteScanResultPartDocumentId', () => {
-        hashGenerator = new HashGenerator(SHA);
-        const id = hashGenerator.getWebsiteScanResultPartDocumentId('baseId', 'scanId');
-        const expectedId = hashGenerator.generateBase64Hash('baseId', 'scanId');
+        const id = hashGenerator.getPageScanDocumentId('pageId', 'websiteScanId');
+        const expectedId = hashGenerator.generateBase64Hash('pageId', 'websiteScanId');
         expect(id).toEqual(expectedId);
     });
 

--- a/packages/common/src/ciphers/hash-generator.ts
+++ b/packages/common/src/ciphers/hash-generator.ts
@@ -12,14 +12,9 @@ const shaJS = require('sha.js');
 export class HashGenerator {
     public constructor(private readonly shaObj = shaJS) {}
 
-    public getWebsiteScanResultDocumentId(baseUrl: string, scanGroupId: string): string {
+    public getPageScanDocumentId(pageId: string, websiteScanId: string): string {
         // Preserve parameters order below for the hash generation compatibility
-        return this.generateBase64Hash(baseUrl, scanGroupId);
-    }
-
-    public getWebsiteScanResultPartDocumentId(baseId: string, scanId: string): string {
-        // Preserve parameters order below for the hash generation compatibility
-        return this.generateBase64Hash(baseId, scanId);
+        return this.generateBase64Hash(pageId, websiteScanId);
     }
 
     public getDbHashBucket(prefix: string, ...values: string[]): string {

--- a/packages/service-library/src/data-providers/page-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, Mock } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { ItemType, Page } from 'storage-documents';
+import { itemTypes, Page } from 'storage-documents';
 import _ from 'lodash';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { PageProvider } from './page-provider';
@@ -21,7 +21,7 @@ describe(PageProvider, () => {
         id: pageId,
         websiteId: websiteId,
         url: url,
-        itemType: ItemType.page,
+        itemType: itemTypes.page,
         partitionKey: partitionKey,
     };
     let cosmosContainerClientMock: IMock<CosmosContainerClient>;
@@ -35,7 +35,7 @@ describe(PageProvider, () => {
         cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
         partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
-        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.page, pageId)).returns(() => partitionKey);
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(itemTypes.page, pageId)).returns(() => partitionKey);
         cosmosQueryResultsProviderMock = Mock.ofInstance(() => null);
 
         testSubject = new PageProvider(
@@ -145,13 +145,13 @@ describe(PageProvider, () => {
                     },
                     {
                         name: '@itemType',
-                        value: ItemType.page,
+                        value: itemTypes.page,
                     },
                 ],
             };
             const iterableStub = {} as CosmosQueryResultsIterable<Page>;
 
-            partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.page, websiteId)).returns(() => partitionKey);
+            partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(itemTypes.page, websiteId)).returns(() => partitionKey);
             cosmosQueryResultsProviderMock.setup((o) => o(cosmosContainerClientMock.object, expectedQuery)).returns(() => iterableStub);
 
             const actualIterable = testSubject.getPagesForWebsite(websiteId);

--- a/packages/service-library/src/data-providers/page-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-provider.spec.ts
@@ -74,7 +74,7 @@ describe(PageProvider, () => {
 
         it('updates doc with normalized properties', async () => {
             const updatedPageData: Partial<Page> = {
-                lastScanDate: new Date(0, 1, 2, 3),
+                lastScanTimestamp: 123456,
                 id: pageId,
             };
             const expectedPageDoc = {

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -18,17 +18,21 @@ export class PageProvider {
         private readonly cosmosQueryResultsProvider: typeof getCosmosQueryResultsIterable = getCosmosQueryResultsIterable,
     ) {}
 
-    public async createPageForWebsite(pageUrl: string, websiteId: string): Promise<void> {
-        const page = this.normalizeDbDocument({
+    public async createPageForWebsite(pageUrl: string, websiteId: string): Promise<Page> {
+        const pageDoc = this.normalizeDbDocument({
             id: this.guidGenerator.createGuidFromBaseGuid(websiteId),
             websiteId: websiteId,
             url: pageUrl,
-        });
-        await this.cosmosContainerClient.writeDocument(page);
+        }) as Page;
+        await this.cosmosContainerClient.writeDocument(pageDoc);
+
+        return pageDoc;
     }
 
-    public async updatePage(page: Partial<Page>): Promise<void> {
-        await this.cosmosContainerClient.mergeOrWriteDocument(this.normalizeDbDocument(page));
+    public async updatePage(page: Partial<Page>): Promise<Page> {
+        const response = await this.cosmosContainerClient.mergeOrWriteDocument<Page>(this.normalizeDbDocument(page) as Page);
+
+        return response.item;
     }
 
     public async readPage(id: string): Promise<Page> {

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -42,11 +42,10 @@ export class PageProvider {
         return response.item;
     }
 
-    public getPagesForWebsite(websiteId: string, selectedProperties?: (keyof Page)[]): CosmosQueryResultsIterable<Page> {
+    public getPagesForWebsite(websiteId: string): CosmosQueryResultsIterable<Page> {
         const partitionKey = this.getPagePartitionKey(websiteId);
-        const selectedPropertiesString = selectedProperties === undefined ? '*' : selectedProperties.join(', ');
         const query = {
-            query: 'SELECT @selectedProperties FROM c WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType',
             parameters: [
                 {
                     name: '@websiteId',
@@ -59,10 +58,6 @@ export class PageProvider {
                 {
                     name: '@itemType',
                     value: ItemType.page,
-                },
-                {
-                    name: '@selectedProperties',
-                    value: selectedPropertiesString,
                 },
             ],
         };

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { ItemType, Page } from 'storage-documents';
+import { itemTypes, Page } from 'storage-documents';
 import { GuidGenerator } from 'common';
 import _ from 'lodash';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
@@ -57,7 +57,7 @@ export class PageProvider {
                 },
                 {
                     name: '@itemType',
-                    value: ItemType.page,
+                    value: itemTypes.page,
                 },
             ],
         };
@@ -66,7 +66,7 @@ export class PageProvider {
     }
 
     private getPagePartitionKey(pageOrWebsiteId: string): string {
-        return this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.page, pageOrWebsiteId);
+        return this.partitionKeyFactory.createPartitionKeyForDocument(itemTypes.page, pageOrWebsiteId);
     }
 
     private normalizeDbDocument(page: Partial<Page>): Partial<Page> {
@@ -75,7 +75,7 @@ export class PageProvider {
         }
 
         return {
-            itemType: ItemType.page,
+            itemType: itemTypes.page,
             partitionKey: this.getPagePartitionKey(page.id),
             ...page,
         };

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -132,7 +132,7 @@ describe(PageScanProvider, () => {
     });
 
     describe('readPageScan', () => {
-        it('reads pageScan with id', async () => {
+        it('reads pageScan with the specified pageId and websiteScanId', async () => {
             const response = {
                 statusCode: 200,
                 item: pageScanDoc,
@@ -157,6 +157,35 @@ describe(PageScanProvider, () => {
                 .verifiable();
 
             expect(testSubject.readPageScan(pageId, websiteScanId)).rejects.toThrow();
+        });
+    });
+
+    describe('readPageScanWithId', () => {
+        it('reads pageScan with id', async () => {
+            const response = {
+                statusCode: 200,
+                item: pageScanDoc,
+            } as CosmosOperationResponse<PageScan>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageScanId))
+                .returns(async () => response)
+                .verifiable();
+
+            const actualPageScan = await testSubject.readPageScanWithId(pageScanId);
+
+            expect(actualPageScan).toBe(pageScanDoc);
+        });
+
+        it('throws if unsuccessful status code', async () => {
+            const response = {
+                statusCode: 404,
+            } as CosmosOperationResponse<PageScan>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageScanId))
+                .returns(async () => response)
+                .verifiable();
+
+            expect(testSubject.readPageScanWithId(pageScanId)).rejects.toThrow();
         });
     });
 

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, It, Mock } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { ItemType, PageScan } from 'storage-documents';
+import { itemTypes, PageScan } from 'storage-documents';
 import _ from 'lodash';
 import { SqlQuerySpec } from '@azure/cosmos';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
@@ -24,7 +24,7 @@ describe(PageScanProvider, () => {
         pageId: pageId,
         websiteScanId: websiteScanId,
         partitionKey: partitionKey,
-        itemType: ItemType.pageScan,
+        itemType: itemTypes.pageScan,
         priority: priority,
         scanStatus: 'pending',
         retryCount: 0,
@@ -40,9 +40,11 @@ describe(PageScanProvider, () => {
         cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
         partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
-        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.pageScan, pageScanId)).returns(() => partitionKey);
-        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.pageScan, pageId)).returns(() => partitionKey);
-        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.pageScan, websiteScanId)).returns(() => partitionKey);
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(itemTypes.pageScan, pageScanId)).returns(() => partitionKey);
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(itemTypes.pageScan, pageId)).returns(() => partitionKey);
+        partitionKeyFactoryMock
+            .setup((p) => p.createPartitionKeyForDocument(itemTypes.pageScan, websiteScanId))
+            .returns(() => partitionKey);
         cosmosQueryResultsProviderMock = Mock.ofInstance(() => null);
 
         testSubject = new PageScanProvider(
@@ -104,7 +106,7 @@ describe(PageScanProvider, () => {
                 pageId: pageId,
             };
             const expectedScanDoc = {
-                itemType: ItemType.pageScan,
+                itemType: itemTypes.pageScan,
                 partitionKey: partitionKey,
                 ...updatedScanData,
             };
@@ -126,7 +128,7 @@ describe(PageScanProvider, () => {
                 websiteScanId: websiteScanId,
             };
             const expectedScanDoc = {
-                itemType: ItemType.pageScan,
+                itemType: itemTypes.pageScan,
                 partitionKey: partitionKey,
                 ...updatedScanData,
             };
@@ -148,7 +150,7 @@ describe(PageScanProvider, () => {
                 partitionKey: 'provided partition key',
             };
             const expectedScanDoc = {
-                itemType: ItemType.pageScan,
+                itemType: itemTypes.pageScan,
                 ...updatedScanData,
             };
 
@@ -203,7 +205,7 @@ describe(PageScanProvider, () => {
                     },
                     {
                         name: '@itemType',
-                        value: ItemType.pageScan,
+                        value: itemTypes.pageScan,
                     },
                     {
                         name: '@websiteScanId',
@@ -283,7 +285,7 @@ describe(PageScanProvider, () => {
                     },
                     {
                         name: '@itemType',
-                        value: ItemType.pageScan,
+                        value: itemTypes.pageScan,
                     },
                     {
                         name: '@websiteScanId',

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -231,7 +231,7 @@ describe(PageScanProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny())).returns(async () => response);
 
-            expect(testSubject.getLatestPageScanFor(websiteScanId, pageId)).rejects.toThrow();
+            expect(testSubject.getLatestPageScan(websiteScanId, pageId)).rejects.toThrow();
         });
 
         it('returns undefined if no results are found', async () => {
@@ -242,7 +242,7 @@ describe(PageScanProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.queryDocuments(It.isAny())).returns(async () => response);
 
-            expect(await testSubject.getLatestPageScanFor(websiteScanId, pageId)).toBeUndefined();
+            expect(await testSubject.getLatestPageScan(websiteScanId, pageId)).toBeUndefined();
         });
 
         it('queries db with expected query', async () => {
@@ -256,7 +256,7 @@ describe(PageScanProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.queryDocuments(expectedQuery)).returns(async () => response);
 
-            const actualResult = await testSubject.getLatestPageScanFor(websiteScanId, pageId);
+            const actualResult = await testSubject.getLatestPageScan(websiteScanId, pageId);
             expect(actualResult).toEqual(pageScanDoc);
         });
 
@@ -271,7 +271,7 @@ describe(PageScanProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.queryDocuments(expectedQuery)).returns(async () => response);
 
-            const actualResult = await testSubject.getLatestPageScanFor(websiteScanId, pageId, true);
+            const actualResult = await testSubject.getLatestPageScan(websiteScanId, pageId, true);
             expect(actualResult).toEqual(pageScanDoc);
         });
 

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { IMock, Mock } from 'typemoq';
+import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
+import { HashGenerator } from 'common';
+import { ItemType, PageScan } from 'storage-documents';
+import _ from 'lodash';
+import { SqlQuerySpec } from '@azure/cosmos';
+import { PartitionKeyFactory } from '../factories/partition-key-factory';
+import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
+import { PageScanProvider } from './page-scan-provider';
+
+describe(PageScanProvider, () => {
+    const websiteScanId = 'website scan id';
+    const pageId = 'page id';
+    const pageScanId = 'page scan id';
+    const partitionKey = 'partition key';
+    const currentDate = new Date(0, 1, 2, 3);
+    const getCurrentDateStub = () => currentDate;
+    const priority = 10;
+    const pageScanDoc = {
+        id: pageScanId,
+        pageId: pageId,
+        websiteScanId: websiteScanId,
+        partitionKey: partitionKey,
+        itemType: ItemType.pageScan,
+        priority: priority,
+        startDate: currentDate,
+        scanStatus: 'pending',
+        retryCount: 0,
+    } as PageScan;
+    let cosmosContainerClientMock: IMock<CosmosContainerClient>;
+    let hashGeneratorMock: IMock<HashGenerator>;
+    let partitionKeyFactoryMock: IMock<PartitionKeyFactory>;
+    let cosmosQueryResultsProviderMock: IMock<typeof getCosmosQueryResultsIterable>;
+
+    let testSubject: PageScanProvider;
+
+    beforeEach(() => {
+        cosmosContainerClientMock = Mock.ofType<CosmosContainerClient>();
+        hashGeneratorMock = Mock.ofType<HashGenerator>();
+        partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.pageScan, pageId)).returns(() => partitionKey);
+        partitionKeyFactoryMock.setup((p) => p.createPartitionKeyForDocument(ItemType.pageScan, websiteScanId)).returns(() => partitionKey);
+        hashGeneratorMock.setup((h) => h.getPageScanDocumentId(pageId, websiteScanId)).returns(() => pageScanId);
+        cosmosQueryResultsProviderMock = Mock.ofInstance(() => null);
+
+        testSubject = new PageScanProvider(
+            cosmosContainerClientMock.object,
+            hashGeneratorMock.object,
+            partitionKeyFactoryMock.object,
+            cosmosQueryResultsProviderMock.object,
+            getCurrentDateStub,
+        );
+    });
+
+    afterEach(() => {
+        hashGeneratorMock.verifyAll();
+        cosmosContainerClientMock.verifyAll();
+        partitionKeyFactoryMock.verifyAll();
+        cosmosQueryResultsProviderMock.verifyAll();
+    });
+
+    describe('createPageScan', () => {
+        it('creates pageScan doc', async () => {
+            cosmosContainerClientMock.setup((c) => c.writeDocument(pageScanDoc)).verifiable();
+
+            await testSubject.createPageScan(pageId, websiteScanId, priority);
+        });
+    });
+
+    describe('updatePageScan', () => {
+        it('throws if no id', () => {
+            const pageScanUpdate: Partial<PageScan> = {
+                scanStatus: 'pass',
+            };
+
+            expect(testSubject.updatePageScan(pageScanUpdate)).rejects.toThrow();
+        });
+
+        it('updates doc with normalized properties when pageId is present', async () => {
+            const updatedScanData: Partial<PageScan> = {
+                scanStatus: 'pass',
+                id: pageScanId,
+                pageId: pageId,
+            };
+            const updatedScanDoc = {
+                itemType: ItemType.pageScan,
+                partitionKey: partitionKey,
+                ...updatedScanData,
+            };
+
+            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+
+            await testSubject.updatePageScan(updatedScanData);
+        });
+
+        it('updates doc with normalized properties when websiteScanId is present', async () => {
+            const updatedScanData: Partial<PageScan> = {
+                scanStatus: 'pass',
+                id: pageScanId,
+                websiteScanId: websiteScanId,
+            };
+            const updatedScanDoc = {
+                itemType: ItemType.pageScan,
+                partitionKey: partitionKey,
+                ...updatedScanData,
+            };
+
+            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+
+            await testSubject.updatePageScan(updatedScanData);
+        });
+
+        it('does not overwrite partitionKey if websiteScanId and pageId are both missing', async () => {
+            const updatedScanData: Partial<PageScan> = {
+                scanStatus: 'pass',
+                id: pageScanId,
+            };
+            const updatedScanDoc = {
+                itemType: ItemType.pageScan,
+                ...updatedScanData,
+            };
+
+            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+
+            await testSubject.updatePageScan(updatedScanData);
+        });
+    });
+
+    describe('readPageScan', () => {
+        it('reads pageScan with id', async () => {
+            const response = {
+                statusCode: 200,
+                item: pageScanDoc,
+            } as CosmosOperationResponse<PageScan>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageScanId, partitionKey))
+                .returns(async () => response)
+                .verifiable();
+
+            const actualPageScan = await testSubject.readPageScan(pageId, websiteScanId);
+
+            expect(actualPageScan).toBe(pageScanDoc);
+        });
+
+        it('throws if unsuccessful status code', async () => {
+            const response = {
+                statusCode: 404,
+            } as CosmosOperationResponse<PageScan>;
+            cosmosContainerClientMock
+                .setup((c) => c.readDocument(pageScanId, partitionKey))
+                .returns(async () => response)
+                .verifiable();
+
+            expect(testSubject.readPageScan(pageId, websiteScanId)).rejects.toThrow();
+        });
+    });
+
+    describe('getPageScansForWebsiteScan', () => {
+        const iterableStub = {} as CosmosQueryResultsIterable<PageScan>;
+
+        it('calls cosmosQueryResultsProvider with expected query', () => {
+            const expectedQuery = getQueryWithSelectedProperties('*');
+
+            cosmosQueryResultsProviderMock.setup((o) => o(cosmosContainerClientMock.object, expectedQuery)).returns(() => iterableStub);
+
+            const actualIterable = testSubject.getPageScansForWebsiteScan(websiteScanId);
+
+            expect(actualIterable).toBe(iterableStub);
+        });
+
+        it('calls cosmosQueryResultsProvider with specific properties selected', () => {
+            const selectedProperties: (keyof PageScan)[] = ['id', 'websiteScanId'];
+            const expectedQuery = getQueryWithSelectedProperties('id, websiteScanId');
+
+            cosmosQueryResultsProviderMock.setup((o) => o(cosmosContainerClientMock.object, expectedQuery)).returns(() => iterableStub);
+
+            const actualIterable = testSubject.getPageScansForWebsiteScan(websiteScanId, selectedProperties);
+
+            expect(actualIterable).toBe(iterableStub);
+        });
+
+        function getQueryWithSelectedProperties(selectedPropertiesString: string): SqlQuerySpec {
+            return {
+                query: `SELECT @selectedProperties FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId`,
+                parameters: [
+                    {
+                        name: '@partitionKey',
+                        value: partitionKey,
+                    },
+                    {
+                        name: '@itemType',
+                        value: ItemType.pageScan,
+                    },
+                    {
+                        name: '@selectedProperties',
+                        value: selectedPropertiesString,
+                    },
+                    {
+                        name: '@websiteScanId',
+                        value: websiteScanId,
+                    },
+                ],
+            };
+        }
+    });
+});

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -68,11 +68,21 @@ describe(PageScanProvider, () => {
         it('creates pageScan doc', async () => {
             cosmosContainerClientMock.setup((c) => c.writeDocument(pageScanDoc)).verifiable();
 
-            await testSubject.createPageScan(pageId, websiteScanId, priority);
+            const actualPageScan = await testSubject.createPageScan(pageId, websiteScanId, priority);
+
+            expect(actualPageScan).toEqual(pageScanDoc);
         });
     });
 
     describe('updatePageScan', () => {
+        const updatedScanDoc = {
+            id: pageScanId,
+        } as PageScan;
+        const successfulUpdateResponse: CosmosOperationResponse<PageScan> = {
+            statusCode: 200,
+            item: updatedScanDoc,
+        };
+
         it('throws if no id', () => {
             const pageScanUpdate: Partial<PageScan> = {
                 scanStatus: 'pass',
@@ -87,15 +97,20 @@ describe(PageScanProvider, () => {
                 id: pageScanId,
                 pageId: pageId,
             };
-            const updatedScanDoc = {
+            const expectedScanDoc = {
                 itemType: ItemType.pageScan,
                 partitionKey: partitionKey,
                 ...updatedScanData,
             };
 
-            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+            cosmosContainerClientMock
+                .setup((c) => c.mergeOrWriteDocument(expectedScanDoc))
+                .returns(async () => successfulUpdateResponse)
+                .verifiable();
 
-            await testSubject.updatePageScan(updatedScanData);
+            const actualPageScan = await testSubject.updatePageScan(updatedScanData);
+
+            expect(actualPageScan).toEqual(updatedScanDoc);
         });
 
         it('updates doc with normalized properties when websiteScanId is present', async () => {
@@ -104,15 +119,20 @@ describe(PageScanProvider, () => {
                 id: pageScanId,
                 websiteScanId: websiteScanId,
             };
-            const updatedScanDoc = {
+            const expectedScanDoc = {
                 itemType: ItemType.pageScan,
                 partitionKey: partitionKey,
                 ...updatedScanData,
             };
 
-            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+            cosmosContainerClientMock
+                .setup((c) => c.mergeOrWriteDocument(expectedScanDoc))
+                .returns(async () => successfulUpdateResponse)
+                .verifiable();
 
-            await testSubject.updatePageScan(updatedScanData);
+            const actualPageScan = await testSubject.updatePageScan(updatedScanData);
+
+            expect(actualPageScan).toEqual(updatedScanDoc);
         });
 
         it('does not overwrite partitionKey if websiteScanId and pageId are both missing', async () => {
@@ -120,14 +140,19 @@ describe(PageScanProvider, () => {
                 scanStatus: 'pass',
                 id: pageScanId,
             };
-            const updatedScanDoc = {
+            const expectedScanDoc = {
                 itemType: ItemType.pageScan,
                 ...updatedScanData,
             };
 
-            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
+            cosmosContainerClientMock
+                .setup((c) => c.mergeOrWriteDocument(expectedScanDoc))
+                .returns(async () => successfulUpdateResponse)
+                .verifiable();
 
-            await testSubject.updatePageScan(updatedScanData);
+            const actualPageScan = await testSubject.updatePageScan(updatedScanData);
+
+            expect(actualPageScan).toEqual(updatedScanDoc);
         });
     });
 

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -70,7 +70,7 @@ export class PageScanProvider {
         return this.cosmosQueryResultsProvider(this.cosmosContainerClient, query);
     }
 
-    public async getLatestPageScanFor(websiteScanId: string, pageId: string, completed?: boolean): Promise<PageScan | undefined> {
+    public async getLatestPageScan(websiteScanId: string, pageId: string, completed?: boolean): Promise<PageScan | undefined> {
         const partitionKey = this.getPageScanPartitionKey(websiteScanId);
         let filterConditions =
             'c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId and c.pageId = @pageId';

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -18,7 +18,7 @@ export class PageScanProvider {
         private readonly getCurrentDate: () => Date = () => new Date(),
     ) {}
 
-    public async createPageScan(pageId: string, websiteScanId: string, priority: number): Promise<void> {
+    public async createPageScan(pageId: string, websiteScanId: string, priority: number): Promise<PageScan> {
         const pageScanData: DocumentDataOnly<PageScan> = {
             id: this.hashGenerator.getPageScanDocumentId(pageId, websiteScanId),
             pageId: pageId,
@@ -28,13 +28,17 @@ export class PageScanProvider {
             scanStatus: 'pending',
             retryCount: 0,
         };
-        const pageScanDocument = this.normalizeDbDocument(pageScanData);
+        const pageScanDocument = this.normalizeDbDocument(pageScanData) as PageScan;
         await this.cosmosContainerClient.writeDocument(this.normalizeDbDocument(pageScanDocument));
+
+        return pageScanDocument;
     }
 
-    public async updatePageScan(pageScan: Partial<PageScan>): Promise<void> {
+    public async updatePageScan(pageScan: Partial<PageScan>): Promise<PageScan> {
         const pageScanDoc = this.normalizeDbDocument(pageScan);
-        await this.cosmosContainerClient.mergeOrWriteDocument(pageScanDoc);
+        const response = await this.cosmosContainerClient.mergeOrWriteDocument(pageScanDoc);
+
+        return response.item as PageScan;
     }
 
     public async readPageScan(pageId: string, websiteScanId: string): Promise<PageScan> {

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -5,7 +5,6 @@ import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure
 import { inject, injectable } from 'inversify';
 import { DocumentDataOnly, ItemType, PageScan } from 'storage-documents';
 import { HashGenerator } from 'common';
-import { SqlQuerySpec } from '@azure/cosmos';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
 
@@ -42,6 +41,13 @@ export class PageScanProvider {
         const pageScanId = this.hashGenerator.getPageScanDocumentId(pageId, websiteScanId);
         const partitionKey = this.getPageScanPartitionKey(pageId);
         const response = await this.cosmosContainerClient.readDocument<PageScan>(pageScanId, partitionKey);
+        client.ensureSuccessStatusCode(response);
+
+        return response.item;
+    }
+
+    public async readPageScanWithId(pageScanId: string): Promise<PageScan> {
+        const response = await this.cosmosContainerClient.readDocument<PageScan>(pageScanId);
         client.ensureSuccessStatusCode(response);
 
         return response.item;

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { DocumentDataOnly, ItemType, PageScan } from 'storage-documents';
+import { DocumentDataOnly, itemTypes, PageScan } from 'storage-documents';
 import { GuidGenerator } from 'common';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
@@ -58,7 +58,7 @@ export class PageScanProvider {
                 },
                 {
                     name: '@itemType',
-                    value: ItemType.pageScan,
+                    value: itemTypes.pageScan,
                 },
                 {
                     name: '@websiteScanId',
@@ -86,7 +86,7 @@ export class PageScanProvider {
                 },
                 {
                     name: '@itemType',
-                    value: ItemType.pageScan,
+                    value: itemTypes.pageScan,
                 },
                 {
                     name: '@websiteScanId',
@@ -113,7 +113,7 @@ export class PageScanProvider {
         }
 
         const normalizedDoc: Partial<PageScan> = {
-            itemType: ItemType.pageScan,
+            itemType: itemTypes.pageScan,
             partitionKey: this.getPageScanPartitionKey(pageScan.id),
             ...pageScan,
         };
@@ -122,6 +122,6 @@ export class PageScanProvider {
     }
 
     private getPageScanPartitionKey(guid: string): string {
-        return this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.pageScan, guid);
+        return this.partitionKeyFactory.createPartitionKeyForDocument(itemTypes.pageScan, guid);
     }
 }

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
+import { inject, injectable } from 'inversify';
+import { DocumentDataOnly, ItemType, PageScan } from 'storage-documents';
+import { HashGenerator } from 'common';
+import { SqlQuerySpec } from '@azure/cosmos';
+import { PartitionKeyFactory } from '../factories/partition-key-factory';
+import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
+
+@injectable()
+export class PageScanProvider {
+    public constructor(
+        @inject(cosmosContainerClientTypes.scanMetadataRepoContainerClient) private readonly cosmosContainerClient: CosmosContainerClient,
+        @inject(HashGenerator) private readonly hashGenerator: HashGenerator,
+        @inject(PartitionKeyFactory) private readonly partitionKeyFactory: PartitionKeyFactory,
+        private readonly cosmosQueryResultsProvider: typeof getCosmosQueryResultsIterable = getCosmosQueryResultsIterable,
+        private readonly getCurrentDate: () => Date = () => new Date(),
+    ) {}
+
+    public async createPageScan(pageId: string, websiteScanId: string, priority: number): Promise<void> {
+        const pageScanData: DocumentDataOnly<PageScan> = {
+            id: this.hashGenerator.getPageScanDocumentId(pageId, websiteScanId),
+            pageId: pageId,
+            websiteScanId: websiteScanId,
+            priority: priority,
+            startDate: this.getCurrentDate(),
+            scanStatus: 'pending',
+            retryCount: 0,
+        };
+        const pageScanDocument = this.normalizeDbDocument(pageScanData);
+        await this.cosmosContainerClient.writeDocument(this.normalizeDbDocument(pageScanDocument));
+    }
+
+    public async updatePageScan(pageScan: Partial<PageScan>): Promise<void> {
+        const pageScanDoc = this.normalizeDbDocument(pageScan);
+        await this.cosmosContainerClient.mergeOrWriteDocument(pageScanDoc);
+    }
+
+    public async readPageScan(pageId: string, websiteScanId: string): Promise<PageScan> {
+        const pageScanId = this.hashGenerator.getPageScanDocumentId(pageId, websiteScanId);
+        const partitionKey = this.getPageScanPartitionKey(pageId);
+        const response = await this.cosmosContainerClient.readDocument<PageScan>(pageScanId, partitionKey);
+        client.ensureSuccessStatusCode(response);
+
+        return response.item;
+    }
+
+    public getPageScansForWebsiteScan(
+        websiteScanId: string,
+        selectedProperties?: (keyof PageScan)[],
+    ): CosmosQueryResultsIterable<PageScan> {
+        const partitionKey = this.getPageScanPartitionKey(websiteScanId);
+        const selectedPropertiesString = selectedProperties === undefined ? '*' : selectedProperties.join(', ');
+        const query = {
+            query: `SELECT @selectedProperties FROM c WHERE c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId`,
+            parameters: [
+                {
+                    name: '@partitionKey',
+                    value: partitionKey,
+                },
+                {
+                    name: '@itemType',
+                    value: ItemType.pageScan,
+                },
+                {
+                    name: '@selectedProperties',
+                    value: selectedPropertiesString,
+                },
+                {
+                    name: '@websiteScanId',
+                    value: websiteScanId,
+                },
+            ],
+        };
+
+        return this.cosmosQueryResultsProvider(this.cosmosContainerClient, query);
+    }
+
+    private normalizeDbDocument(pageScan: Partial<PageScan>): Partial<PageScan> {
+        if (pageScan.id === undefined) {
+            throw new Error('Page scan document has no id');
+        }
+
+        const normalizedDoc: Partial<PageScan> = {
+            itemType: ItemType.pageScan,
+            ...pageScan,
+        };
+
+        if (pageScan.pageId !== undefined || pageScan.websiteScanId !== undefined) {
+            const partitionKey = this.getPageScanPartitionKey(pageScan.pageId ?? pageScan.websiteScanId);
+            normalizedDoc.partitionKey = normalizedDoc.partitionKey ?? partitionKey;
+        }
+
+        return normalizedDoc;
+    }
+
+    private getPageScanPartitionKey(pageOrWebsiteScanId: string): string {
+        return this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.pageScan, pageOrWebsiteScanId);
+    }
+}

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -42,7 +42,8 @@ describe(WebsiteProvider, () => {
                 .verifiable();
             cosmosContainerClientMock.setup((c) => c.writeDocument(expectedDocument)).verifiable();
 
-            await testSubject.createWebsite(websiteData);
+            const actualWebsite = await testSubject.createWebsite(websiteData);
+            expect(actualWebsite).toEqual(expectedDocument);
         });
 
         it('does not overwrite existing id', async () => {
@@ -55,7 +56,8 @@ describe(WebsiteProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.writeDocument(expectedDocument)).verifiable();
 
-            await testSubject.createWebsite(websiteData);
+            const actualWebsite = await testSubject.createWebsite(websiteData);
+            expect(actualWebsite).toEqual(expectedDocument);
         });
     });
 
@@ -74,8 +76,19 @@ describe(WebsiteProvider, () => {
                 id: websiteId,
             };
             const expectedDocument = getNormalizedDocument(websiteData);
+            const updatedDocument = {
+                name: 'updated test website',
+                id: websiteId,
+            } as Website;
+            const response: CosmosOperationResponse<Website> = {
+                statusCode: 200,
+                item: updatedDocument,
+            };
 
-            cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(expectedDocument)).verifiable();
+            cosmosContainerClientMock
+                .setup((c) => c.mergeOrWriteDocument(expectedDocument))
+                .returns(async () => response)
+                .verifiable();
 
             await testSubject.updateWebsite(websiteData);
         });

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { DocumentDataOnly, ItemType, PartitionKey, Website } from 'storage-documents';
+import { DocumentDataOnly, itemTypes, PartitionKey, Website } from 'storage-documents';
 import { WebsiteProvider } from './website-provider';
 
 describe(WebsiteProvider, () => {
@@ -129,7 +129,7 @@ describe(WebsiteProvider, () => {
     function getNormalizedDocument(website: Partial<Website>): Partial<Website> {
         return {
             id: websiteId,
-            itemType: ItemType.website,
+            itemType: itemTypes.website,
             partitionKey: PartitionKey.websiteDocuments,
             ...website,
         };

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { DocumentDataOnly, ItemType, PartitionKey, Website } from 'storage-documents';
+import { DocumentDataOnly, itemTypes, PartitionKey, Website } from 'storage-documents';
 import { GuidGenerator } from 'common';
 
 @injectable()
@@ -42,7 +42,7 @@ export class WebsiteProvider {
 
         return {
             id: id,
-            itemType: ItemType.website,
+            itemType: itemTypes.website,
             partitionKey: PartitionKey.websiteDocuments,
             ...website,
         };

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -13,14 +13,19 @@ export class WebsiteProvider {
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
     ) {}
 
-    public async createWebsite(websiteData: DocumentDataOnly<Website>): Promise<void> {
+    public async createWebsite(websiteData: DocumentDataOnly<Website>): Promise<Website> {
         const websiteDoc = this.normalizeDbDocument(websiteData, this.guidGenerator.createGuid());
         await this.cosmosContainerClient.writeDocument(websiteDoc);
+
+        return websiteDoc as Website;
     }
 
-    public async updateWebsite(website: Partial<Website>): Promise<void> {
+    public async updateWebsite(website: Partial<Website>): Promise<Website> {
         const websiteDoc = this.normalizeDbDocument(website);
-        await this.cosmosContainerClient.mergeOrWriteDocument(websiteDoc);
+
+        const response = await this.cosmosContainerClient.mergeOrWriteDocument(websiteDoc);
+
+        return response.item as Website;
     }
 
     public async readWebsite(id: string): Promise<Website> {

--- a/packages/service-library/src/data-providers/website-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { IMock, Mock } from 'typemoq';
 import { CosmosContainerClient, CosmosOperationResponse } from 'azure-services';
 import { GuidGenerator } from 'common';
-import { ItemType, WebsiteScan } from 'storage-documents';
+import { itemTypes, WebsiteScan } from 'storage-documents';
 import _ from 'lodash';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
@@ -22,7 +22,7 @@ describe(WebsiteScanProvider, () => {
         scanType: 'a11y',
         scanFrequency: 5,
         scanStatus: 'pending',
-        itemType: ItemType.websiteScan,
+        itemType: itemTypes.websiteScan,
         partitionKey: partitionKey,
     };
     let cosmosContainerClientMock: IMock<CosmosContainerClient>;
@@ -37,7 +37,7 @@ describe(WebsiteScanProvider, () => {
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
         partitionKeyFactoryMock = Mock.ofType<PartitionKeyFactory>();
         partitionKeyFactoryMock
-            .setup((p) => p.createPartitionKeyForDocument(ItemType.websiteScan, websiteScanId))
+            .setup((p) => p.createPartitionKeyForDocument(itemTypes.websiteScan, websiteScanId))
             .returns(() => partitionKey);
         cosmosQueryResultsProviderMock = Mock.ofInstance(() => null);
 
@@ -86,7 +86,7 @@ describe(WebsiteScanProvider, () => {
                 id: websiteScanId,
             };
             const expectedScanDoc = {
-                itemType: ItemType.websiteScan,
+                itemType: itemTypes.websiteScan,
                 partitionKey: partitionKey,
                 ...updatedScanData,
             };
@@ -153,14 +153,14 @@ describe(WebsiteScanProvider, () => {
                     },
                     {
                         name: '@itemType',
-                        value: ItemType.websiteScan,
+                        value: itemTypes.websiteScan,
                     },
                 ],
             };
             const iterableStub = {} as CosmosQueryResultsIterable<WebsiteScan>;
 
             partitionKeyFactoryMock
-                .setup((p) => p.createPartitionKeyForDocument(ItemType.websiteScan, websiteId))
+                .setup((p) => p.createPartitionKeyForDocument(itemTypes.websiteScan, websiteId))
                 .returns(() => partitionKey);
             cosmosQueryResultsProviderMock.setup((o) => o(cosmosContainerClientMock.object, expectedQuery)).returns(() => iterableStub);
 

--- a/packages/service-library/src/data-providers/website-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.spec.ts
@@ -72,7 +72,7 @@ describe(WebsiteScanProvider, () => {
                 scanType: 'a11y',
             };
 
-            expect(testSubject.updateWebsitecan(websiteScanData)).rejects.toThrow();
+            expect(testSubject.updateWebsiteScan(websiteScanData)).rejects.toThrow();
         });
 
         it('updates doc with normalized properties', async () => {
@@ -88,7 +88,7 @@ describe(WebsiteScanProvider, () => {
 
             cosmosContainerClientMock.setup((c) => c.mergeOrWriteDocument(updatedScanDoc)).verifiable();
 
-            await testSubject.updateWebsitecan(updatedScanData);
+            await testSubject.updateWebsiteScan(updatedScanData);
         });
     });
 

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -17,7 +17,7 @@ export class WebsiteScanProvider {
         private readonly cosmosQueryResultsProvider: typeof getCosmosQueryResultsIterable = getCosmosQueryResultsIterable,
     ) {}
 
-    public async createScanDocumentForWebsite(websiteId: string, scanType: ScanType, frequency: number): Promise<void> {
+    public async createScanDocumentForWebsite(websiteId: string, scanType: ScanType, frequency: number): Promise<WebsiteScan> {
         const websiteScanData: DocumentDataOnly<WebsiteScan> = {
             id: this.guidGenerator.createGuidFromBaseGuid(websiteId),
             websiteId: websiteId,
@@ -25,12 +25,17 @@ export class WebsiteScanProvider {
             scanFrequency: frequency,
             scanStatus: 'pending',
         };
-        await this.cosmosContainerClient.writeDocument(this.normalizeDbDocument(websiteScanData));
+        const websiteScanDoc = this.normalizeDbDocument(websiteScanData) as WebsiteScan;
+        await this.cosmosContainerClient.writeDocument(websiteScanDoc);
+
+        return websiteScanDoc;
     }
 
-    public async updateWebsiteScan(websiteScan: Partial<WebsiteScan>): Promise<void> {
+    public async updateWebsiteScan(websiteScan: Partial<WebsiteScan>): Promise<WebsiteScan> {
         const websiteScanDoc = this.normalizeDbDocument(websiteScan);
-        await this.cosmosContainerClient.mergeOrWriteDocument(websiteScanDoc);
+        const response = await this.cosmosContainerClient.mergeOrWriteDocument(websiteScanDoc);
+
+        return response.item as WebsiteScan;
     }
 
     public async readWebsiteScan(id: string): Promise<WebsiteScan> {

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -45,11 +45,10 @@ export class WebsiteScanProvider {
         return response.item;
     }
 
-    public getScansForWebsite(websiteId: string, selectedProperties?: (keyof WebsiteScan)[]): CosmosQueryResultsIterable<WebsiteScan> {
+    public getScansForWebsite(websiteId: string): CosmosQueryResultsIterable<WebsiteScan> {
         const partitionKey = this.getWebsiteScanPartitionKey(websiteId);
-        const selectedPropertiesString = selectedProperties === undefined ? '*' : selectedProperties.join(', ');
         const query = {
-            query: 'SELECT @selectedProperties FROM c WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType',
+            query: 'SELECT * FROM c WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType',
             parameters: [
                 {
                     name: '@websiteId',
@@ -62,10 +61,6 @@ export class WebsiteScanProvider {
                 {
                     name: '@itemType',
                     value: ItemType.websiteScan,
-                },
-                {
-                    name: '@selectedProperties',
-                    value: selectedPropertiesString,
                 },
             ],
         };

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -28,13 +28,13 @@ export class WebsiteScanProvider {
         await this.cosmosContainerClient.writeDocument(this.normalizeDbDocument(websiteScanData));
     }
 
-    public async updateWebsitecan(websiteScan: Partial<WebsiteScan>): Promise<void> {
-        const websiteDoc = this.normalizeDbDocument(websiteScan);
-        await this.cosmosContainerClient.mergeOrWriteDocument(websiteDoc);
+    public async updateWebsiteScan(websiteScan: Partial<WebsiteScan>): Promise<void> {
+        const websiteScanDoc = this.normalizeDbDocument(websiteScan);
+        await this.cosmosContainerClient.mergeOrWriteDocument(websiteScanDoc);
     }
 
-    public async readWebsiteScan(id: string): Promise<Website> {
-        const response = await this.cosmosContainerClient.readDocument<Website>(id, this.getWebsiteScanPartitionKey(id));
+    public async readWebsiteScan(id: string): Promise<WebsiteScan> {
+        const response = await this.cosmosContainerClient.readDocument<WebsiteScan>(id, this.getWebsiteScanPartitionKey(id));
         client.ensureSuccessStatusCode(response);
 
         return response.item;

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { DocumentDataOnly, ItemType, ScanType, Website, WebsiteScan } from 'storage-documents';
+import { DocumentDataOnly, ItemType, ScanType, WebsiteScan } from 'storage-documents';
 import { GuidGenerator } from 'common';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -3,7 +3,7 @@
 
 import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
 import { inject, injectable } from 'inversify';
-import { DocumentDataOnly, ItemType, ScanType, WebsiteScan } from 'storage-documents';
+import { DocumentDataOnly, itemTypes, ScanType, WebsiteScan } from 'storage-documents';
 import { GuidGenerator } from 'common';
 import { PartitionKeyFactory } from '../factories/partition-key-factory';
 import { CosmosQueryResultsIterable, getCosmosQueryResultsIterable } from './cosmos-query-results-iterable';
@@ -60,7 +60,7 @@ export class WebsiteScanProvider {
                 },
                 {
                     name: '@itemType',
-                    value: ItemType.websiteScan,
+                    value: itemTypes.websiteScan,
                 },
             ],
         };
@@ -74,13 +74,13 @@ export class WebsiteScanProvider {
         }
 
         return {
-            itemType: ItemType.websiteScan,
+            itemType: itemTypes.websiteScan,
             partitionKey: this.getWebsiteScanPartitionKey(websiteScan.id),
             ...websiteScan,
         };
     }
 
     private getWebsiteScanPartitionKey(scanOrWebsiteId: string): string {
-        return this.partitionKeyFactory.createPartitionKeyForDocument(ItemType.websiteScan, scanOrWebsiteId);
+        return this.partitionKeyFactory.createPartitionKeyForDocument(itemTypes.websiteScan, scanOrWebsiteId);
     }
 }

--- a/packages/service-library/src/factories/partition-key-factory.spec.ts
+++ b/packages/service-library/src/factories/partition-key-factory.spec.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 
 import { GuidGenerator, HashGenerator } from 'common';
 import { IMock, Mock } from 'typemoq';
-import { ItemType } from 'storage-documents';
+import { itemTypes } from 'storage-documents';
 import { PartitionKeyFactory } from './partition-key-factory';
 
 let hashGeneratorMock: IMock<HashGenerator>;
@@ -28,7 +28,7 @@ describe(PartitionKeyFactory, () => {
         const documentId = 'doc1';
         const partitionKeyResult = 'itemType-10';
         setupGenerators('page', documentId, partitionKeyResult);
-        const partitionKey = partitionKeyFactory.createPartitionKeyForDocument(ItemType.page, documentId);
+        const partitionKey = partitionKeyFactory.createPartitionKeyForDocument(itemTypes.page, documentId);
         expect(partitionKey).toEqual(partitionKeyResult);
     });
 });

--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -8,3 +8,7 @@ export { WebControllerDispatcher, Newable } from './web-api/web-controller-dispa
 export { getGlobalWebControllerDispatcher } from './web-api/get-global-web-controller-dispatcher';
 export * from './web-api/web-api-error-codes';
 export { HttpResponse } from './web-api/http-response';
+export { PageProvider } from './data-providers/page-provider';
+export { PageScanProvider } from './data-providers/page-scan-provider';
+export { WebsiteProvider } from './data-providers/website-provider';
+export { WebsiteScanProvider } from './data-providers/website-scan-provider';

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export { ItemType } from './item-type';
+export { itemTypes, ItemType } from './item-type';
 export { PageScan } from './page-scan';
 export { Page } from './page';
 export { PartitionKey } from './partition-key';

--- a/packages/storage-documents/src/item-type.ts
+++ b/packages/storage-documents/src/item-type.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export enum ItemType {
-    website = 'website',
-    page = 'page',
-    websiteScan = 'websiteScan',
-    pageScan = 'page',
-}
+export const itemTypes = {
+    website: 'website',
+    page: 'page',
+    websiteScan: 'websiteScan',
+    pageScan: 'pageScan',
+};
+
+export type ItemTypes = typeof itemTypes;
+
+export type ItemType = ItemTypes[keyof ItemTypes];

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -16,8 +16,7 @@ export interface PageScan extends StorageDocument {
     pageId: string; // maps to a Page document
     priority: number;
     scanStatus: ScanStatus;
-    startDate: Date;
-    completedDate?: Date;
+    completedTimestamp?: number;
     resultsBlobId?: string;
     reports?: ReportData[];
     retryCount: number;

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ItemType } from './item-type';
 import { ReportData } from './report-data';
 import { ScanStatus } from './scan-types';
 import { StorageDocument } from './storage-document';
+import { ItemTypes } from './item-type';
 
 /*
  * Represents a scan/crawl of a single URL for one scan type.
  * Must have a unique combination of pageId and websiteScanId.
  */
 export interface PageScan extends StorageDocument {
-    itemType: ItemType.pageScan;
+    itemType: ItemTypes['pageScan'];
     websiteScanId: string; // maps to a WebsiteScan document
     pageId: string; // maps to a Page document
     priority: number;

--- a/packages/storage-documents/src/page.ts
+++ b/packages/storage-documents/src/page.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ItemType } from './item-type';
+import { ItemTypes } from './item-type';
 import { StorageDocument } from './storage-document';
 
 export interface Page extends StorageDocument {
-    itemType: ItemType.page;
+    itemType: ItemTypes['page'];
     websiteId: string; // maps to a Website document
     url: string;
     lastScanTimestamp?: number;

--- a/packages/storage-documents/src/page.ts
+++ b/packages/storage-documents/src/page.ts
@@ -8,5 +8,5 @@ export interface Page extends StorageDocument {
     itemType: ItemType.page;
     websiteId: string; // maps to a Website document
     url: string;
-    lastScanDate?: Date;
+    lastScanTimestamp?: number;
 }

--- a/packages/storage-documents/src/website-scan.ts
+++ b/packages/storage-documents/src/website-scan.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ItemType } from './item-type';
+import { ItemTypes } from './item-type';
 import { ReportData } from './report-data';
 import { ScanStatus, ScanType } from './scan-types';
 import { StorageDocument } from './storage-document';
@@ -10,7 +10,7 @@ import { StorageDocument } from './storage-document';
  * Represents a scan/crawl of a full website for one scan type
  */
 export interface WebsiteScan extends StorageDocument {
-    itemType: ItemType.websiteScan;
+    itemType: ItemTypes['websiteScan'];
     websiteId: string; // Maps to a Website
     scanType: ScanType;
     scanFrequency: number;

--- a/packages/storage-documents/src/website-scan.ts
+++ b/packages/storage-documents/src/website-scan.ts
@@ -15,5 +15,5 @@ export interface WebsiteScan extends StorageDocument {
     scanType: ScanType;
     scanFrequency: number;
     scanStatus: ScanStatus;
-    reports: ReportData[];
+    reports?: ReportData[];
 }

--- a/packages/storage-documents/src/website.ts
+++ b/packages/storage-documents/src/website.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ItemType } from './item-type';
+import { ItemTypes } from './item-type';
 import { ScanType } from './scan-types';
 import { StorageDocument } from './storage-document';
 
 export interface Website extends StorageDocument {
     name: string;
-    itemType: ItemType.website;
+    itemType: ItemTypes['website'];
     baseUrl: string;
     priority: number;
     discoveryPatterns: string[];

--- a/packages/storage-web-api/package.json
+++ b/packages/storage-web-api/package.json
@@ -47,7 +47,7 @@
     "dependencies": {
         "@azure/functions": "^1.2.3",
         "applicationinsights-native-metrics": "^0.0.6",
-        "azure-services": "^1.0.0",
+        "azure-services": "1.0.0",
         "common": "^1.0.0",
         "inversify": "^5.1.1",
         "lodash": "^4.17.21",


### PR DESCRIPTION
#### Details

Create WebsiteScanProvider and PageScanProvider and update existing providers so create and update operations return the full document

##### Motivation

Expose access to the scan metadata storage documents

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
