### PR TITLE
refactor: WebRequestValidator

### DIFF
--- a/packages/service-library/src/index.ts
+++ b/packages/service-library/src/index.ts
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 export { ProcessEntryPointBase } from './process-entry-point-base';
-export { WebController } from './web-api/web-controller';
 export { ApiController } from './web-api/api-controller';
+export { ApiRequestValidator } from './web-api/api-request-validator';
+export { WebController } from './web-api/web-controller';
 export { WebControllerDispatcher, Newable } from './web-api/web-controller-dispatcher';
+export { WebRequestValidator } from './web-api/web-request-validator';
 export { getGlobalWebControllerDispatcher } from './web-api/get-global-web-controller-dispatcher';
 export * from './web-api/web-api-error-codes';
 export { HttpResponse } from './web-api/http-response';

--- a/packages/service-library/src/web-api/api-controller.ts
+++ b/packages/service-library/src/web-api/api-controller.ts
@@ -32,58 +32,6 @@ export abstract class ApiController extends WebController {
         return undefined;
     }
 
-    protected validateRequest(...args: any[]): boolean {
-        if (!this.validateApiVersion() || !this.validateContentType()) {
-            return false;
-        }
-
-        return true;
-    }
-
-    protected validateContentType(): boolean {
-        if (this.context.req.method !== 'POST' && this.context.req.method !== 'PUT') {
-            return true;
-        }
-
-        if (!this.hasPayload()) {
-            this.context.res = {
-                status: 204, // No Content
-            };
-
-            return false;
-        }
-
-        if (this.context.req.headers === undefined || this.context.req.headers['content-type'] === undefined) {
-            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader);
-
-            return false;
-        }
-
-        if (this.context.req.headers['content-type'] !== 'application/json') {
-            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedContentType);
-
-            return false;
-        }
-
-        return true;
-    }
-
-    protected validateApiVersion(): boolean {
-        if (this.context.req.query === undefined || this.context.req.query['api-version'] === undefined) {
-            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter);
-
-            return false;
-        }
-
-        if (this.context.req.query['api-version'] !== this.apiVersion && this.context.req.query['api-version'] !== '2.0') {
-            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion);
-
-            return false;
-        }
-
-        return true;
-    }
-
     protected async getRestApiConfig(): Promise<RestApiConfig> {
         return this.serviceConfig.getConfigValue('restApiConfig');
     }

--- a/packages/service-library/src/web-api/api-request-validator.spec.ts
+++ b/packages/service-library/src/web-api/api-request-validator.spec.ts
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Context } from '@azure/functions';
+import { ApiRequestValidator } from './api-request-validator';
+import { HttpResponse } from './http-response';
+import { WebApiErrorCodes } from './web-api-error-codes';
+
+describe(ApiRequestValidator, () => {
+    const apiVersion = 'apiVersion';
+
+    let testSubject: ApiRequestValidator;
+
+    beforeEach(() => {
+        testSubject = new ApiRequestValidator([apiVersion]);
+    });
+
+    it('rejects request with no query parameters', () => {
+        const context = <Context>(<unknown>{
+            req: {
+                method: 'GET',
+            },
+        });
+
+        expect(testSubject.validateRequest(context)).toBeFalse();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter));
+    });
+
+    it('rejects request with missing api version', () => {
+        const context = <Context>(<unknown>{
+            req: {
+                method: 'GET',
+                query: {},
+            },
+        });
+
+        expect(testSubject.validateRequest(context)).toBeFalse();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter));
+    });
+
+    it('rejects request with unsupported api version', () => {
+        const context = <Context>(<unknown>{
+            req: {
+                method: 'GET',
+                query: {
+                    'api-version': 'unsupportedApiVersion',
+                },
+            },
+        });
+
+        expect(testSubject.validateRequest(context)).toBeFalse();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+    });
+
+    it('Accepts GET request with supported api version', () => {
+        const context = <Context>(<unknown>{
+            req: {
+                method: 'GET',
+                query: {
+                    'api-version': apiVersion,
+                },
+            },
+        });
+
+        expect(testSubject.validateRequest(context)).toBeTrue();
+    });
+
+    describe.each(['POST', 'PUT'])('%s request', (method) => {
+        let context: Context;
+        const validPayload = JSON.stringify({ id: 'testId' });
+
+        beforeEach(() => {
+            context = <Context>(<unknown>{
+                req: {
+                    method: method,
+                    query: {
+                        'api-version': apiVersion,
+                    },
+                },
+            });
+        });
+
+        it('rejects when there is no payload', () => {
+            expect(testSubject.validateRequest(context)).toBeFalse();
+            expect(context.res.status).toEqual(204);
+        });
+
+        it.each([undefined, '{}'])('rejects when payload=%s', (payload) => {
+            context.req.rawBody = payload;
+
+            expect(testSubject.validateRequest(context)).toBeFalse();
+            expect(context.res.status).toEqual(204);
+        });
+
+        it('rejects when body is invalid JSON', () => {
+            context.req.rawBody = 'invalid JSON string';
+
+            expect(testSubject.validateRequest(context)).toBeFalse();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidJsonDocument));
+        });
+
+        it.each([undefined, {}])('rejects with missingContentTypeHeader when headers=%s', (headers) => {
+            context.req.rawBody = validPayload;
+            context.req.headers = headers;
+
+            expect(testSubject.validateRequest(context)).toBeFalse();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader));
+        });
+
+        it("rejects if content type is not 'application/json'", () => {
+            context.req.rawBody = validPayload;
+            context.req.headers = {
+                'content-type': 'text/plain',
+            };
+
+            expect(testSubject.validateRequest(context)).toBeFalse();
+            expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedContentType));
+        });
+
+        it('accepts request with valid payload and correct content type', () => {
+            context.req.rawBody = validPayload;
+            context.req.headers = {
+                'content-type': 'application/json',
+            };
+
+            expect(testSubject.validateRequest(context)).toBeTrue();
+        });
+    });
+});

--- a/packages/service-library/src/web-api/api-request-validator.spec.ts
+++ b/packages/service-library/src/web-api/api-request-validator.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import 'reflect-metadata';
+
 import { Context } from '@azure/functions';
 import { ApiRequestValidator } from './api-request-validator';
 import { HttpResponse } from './http-response';
@@ -11,8 +13,12 @@ describe(ApiRequestValidator, () => {
 
     let testSubject: ApiRequestValidator;
 
+    class TestableApiRequestValidator extends ApiRequestValidator {
+        protected readonly apiVersions = [apiVersion];
+    }
+
     beforeEach(() => {
-        testSubject = new ApiRequestValidator([apiVersion]);
+        testSubject = new TestableApiRequestValidator();
     });
 
     it('rejects request with no query parameters', () => {

--- a/packages/service-library/src/web-api/api-request-validator.ts
+++ b/packages/service-library/src/web-api/api-request-validator.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Context } from '@azure/functions';
+import _ from 'lodash';
+import { HttpResponse } from './http-response';
+import { WebApiErrorCodes } from './web-api-error-codes';
+import { WebRequestValidator } from './web-request-validator';
+
+export class ApiRequestValidator implements WebRequestValidator {
+    constructor(protected readonly apiVersions: string[]) {}
+
+    public validateRequest(context: Context): boolean {
+        if (!this.validateApiVersion(context) || !this.validateContentType(context)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected validateContentType(context: Context): boolean {
+        if (context.req.method !== 'POST' && context.req.method !== 'PUT') {
+            return true;
+        }
+
+        if (!this.hasPayload(context)) {
+            context.res = context.res || {
+                status: 204, // No Content
+            };
+
+            return false;
+        }
+
+        if (context.req.headers === undefined || context.req.headers['content-type'] === undefined) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingContentTypeHeader);
+
+            return false;
+        }
+
+        if (context.req.headers['content-type'] !== 'application/json') {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedContentType);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected validateApiVersion(context: Context): boolean {
+        if (context.req.query === undefined || context.req.query['api-version'] === undefined) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.missingApiVersionQueryParameter);
+
+            return false;
+        }
+
+        if (!this.apiVersions.includes(context.req.query['api-version'])) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    protected hasPayload(context: Context): boolean {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return context.req.rawBody !== undefined && !_.isEmpty(this.tryGetPayload<any>(context));
+    }
+
+    /**
+     * Try parse a JSON string from the HTTP request body.
+     * Will return undefined if parsing was unsuccessful; otherwise object representation of a JSON string.
+     */
+    protected tryGetPayload<T>(context: Context): T {
+        try {
+            return JSON.parse(context.req.rawBody);
+        } catch (error) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidJsonDocument);
+        }
+
+        return undefined;
+    }
+}

--- a/packages/service-library/src/web-api/api-request-validator.ts
+++ b/packages/service-library/src/web-api/api-request-validator.ts
@@ -2,13 +2,15 @@
 // Licensed under the MIT License.
 
 import { Context } from '@azure/functions';
+import { injectable } from 'inversify';
 import _ from 'lodash';
 import { HttpResponse } from './http-response';
 import { WebApiErrorCodes } from './web-api-error-codes';
 import { WebRequestValidator } from './web-request-validator';
 
-export class ApiRequestValidator implements WebRequestValidator {
-    constructor(protected readonly apiVersions: string[]) {}
+@injectable()
+export abstract class ApiRequestValidator implements WebRequestValidator {
+    protected abstract readonly apiVersions: string[];
 
     public validateRequest(context: Context): boolean {
         if (!this.validateApiVersion(context) || !this.validateContentType(context)) {

--- a/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
+++ b/packages/service-library/src/web-api/web-controller-dispatcher.spec.ts
@@ -10,6 +10,7 @@ import { IMock, Mock, Times } from 'typemoq';
 import { MockableLogger } from '../test-utilities/mockable-logger';
 import { WebController } from './web-controller';
 import { WebControllerDispatcher } from './web-controller-dispatcher';
+import { WebRequestValidator } from './web-request-validator';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -45,11 +46,13 @@ describe(WebControllerDispatcher, () => {
     let testableWebController: TestableWebController;
     let processLifeCycleContainerMock: IMock<Container>;
     let loggerMock: IMock<MockableLogger>;
+    let requestValidatorMock: IMock<WebRequestValidator>;
 
     beforeEach(() => {
         context = <Context>(<unknown>{ bindingDefinitions: {} });
         loggerMock = Mock.ofType(MockableLogger);
-        testableWebController = new TestableWebController(loggerMock.object);
+        requestValidatorMock = Mock.ofType<WebRequestValidator>();
+        testableWebController = new TestableWebController(loggerMock.object, requestValidatorMock.object);
 
         containerMock = Mock.ofType(Container);
         processLifeCycleContainerMock = Mock.ofType(Container);

--- a/packages/service-library/src/web-api/web-controller.ts
+++ b/packages/service-library/src/web-api/web-controller.ts
@@ -5,6 +5,7 @@ import { Context } from '@azure/functions';
 import { System } from 'common';
 import { inject, injectable } from 'inversify';
 import { ContextAwareLogger } from 'logger';
+import { WebRequestValidator } from './web-request-validator';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -12,7 +13,10 @@ import { ContextAwareLogger } from 'logger';
 export abstract class WebController {
     public context: Context;
 
-    constructor(@inject(ContextAwareLogger) protected readonly logger: ContextAwareLogger) {}
+    constructor(
+        @inject(ContextAwareLogger) protected readonly logger: ContextAwareLogger,
+        protected readonly requestValidator: WebRequestValidator,
+    ) {}
 
     public abstract readonly apiVersion: string;
 
@@ -25,7 +29,7 @@ export abstract class WebController {
             this.logger.setCommonProperties(this.getBaseTelemetryProperties());
 
             let result: unknown;
-            if (this.validateRequest(...args)) {
+            if (this.requestValidator.validateRequest(this.context)) {
                 result = await this.handleRequest(...args);
             }
 
@@ -37,8 +41,6 @@ export abstract class WebController {
             throw error;
         }
     }
-
-    protected abstract validateRequest(...args: any[]): boolean;
 
     protected abstract handleRequest(...args: any[]): Promise<unknown>;
 

--- a/packages/service-library/src/web-api/web-request-validator.ts
+++ b/packages/service-library/src/web-api/web-request-validator.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Context } from '@azure/functions';
+
+export interface WebRequestValidator {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    validateRequest(context: Context): boolean;
+}

--- a/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
@@ -7,17 +7,11 @@ import * as ApiContracts from 'api-contracts';
 import { IMock, Mock } from 'typemoq';
 import { ServiceConfiguration } from 'common';
 import { ContextAwareLogger } from 'logger';
-import {
-    ApiRequestValidator,
-    CosmosQueryResultsIterable,
-    HttpResponse,
-    PageProvider,
-    WebApiErrorCodes,
-    WebsiteProvider,
-} from 'service-library';
+import { CosmosQueryResultsIterable, HttpResponse, PageProvider, WebApiErrorCodes, WebsiteProvider } from 'service-library';
 import { Context } from '@azure/functions';
 import * as StorageDocuments from 'storage-documents';
 import { WebsiteDocumentResponseConverter } from '../converters/website-document-response-converter';
+import { GetWebsiteRequestValidator } from '../request-validators/get-website-request-validator';
 import { GetWebsiteController } from './get-website-controller';
 
 describe(GetWebsiteController, () => {
@@ -25,7 +19,7 @@ describe(GetWebsiteController, () => {
     const websiteId = 'website id';
     let serviceConfigMock: IMock<ServiceConfiguration>;
     let loggerMock: IMock<ContextAwareLogger>;
-    let requestValidatorMock: IMock<ApiRequestValidator>;
+    let requestValidatorMock: IMock<GetWebsiteRequestValidator>;
     let websiteProviderMock: IMock<WebsiteProvider>;
     let pageProviderMock: IMock<PageProvider>;
     let websiteDocumentResponseConverterMock: IMock<WebsiteDocumentResponseConverter>;
@@ -36,7 +30,7 @@ describe(GetWebsiteController, () => {
     beforeEach(() => {
         serviceConfigMock = Mock.ofType<ServiceConfiguration>();
         loggerMock = Mock.ofType<ContextAwareLogger>();
-        requestValidatorMock = Mock.ofType<ApiRequestValidator>();
+        requestValidatorMock = Mock.ofType<GetWebsiteRequestValidator>();
         websiteProviderMock = Mock.ofType<WebsiteProvider>();
         pageProviderMock = Mock.ofType<PageProvider>();
         websiteDocumentResponseConverterMock = Mock.ofType<WebsiteDocumentResponseConverter>();

--- a/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
@@ -7,7 +7,14 @@ import * as ApiContracts from 'api-contracts';
 import { IMock, Mock } from 'typemoq';
 import { ServiceConfiguration } from 'common';
 import { ContextAwareLogger } from 'logger';
-import { CosmosQueryResultsIterable, HttpResponse, PageProvider, WebApiErrorCodes, WebsiteProvider } from 'service-library';
+import {
+    ApiRequestValidator,
+    CosmosQueryResultsIterable,
+    HttpResponse,
+    PageProvider,
+    WebApiErrorCodes,
+    WebsiteProvider,
+} from 'service-library';
 import { Context } from '@azure/functions';
 import * as StorageDocuments from 'storage-documents';
 import { WebsiteDocumentResponseConverter } from '../converters/website-document-response-converter';
@@ -18,6 +25,7 @@ describe(GetWebsiteController, () => {
     const websiteId = 'website id';
     let serviceConfigMock: IMock<ServiceConfiguration>;
     let loggerMock: IMock<ContextAwareLogger>;
+    let requestValidatorMock: IMock<ApiRequestValidator>;
     let websiteProviderMock: IMock<WebsiteProvider>;
     let pageProviderMock: IMock<PageProvider>;
     let websiteDocumentResponseConverterMock: IMock<WebsiteDocumentResponseConverter>;
@@ -28,6 +36,7 @@ describe(GetWebsiteController, () => {
     beforeEach(() => {
         serviceConfigMock = Mock.ofType<ServiceConfiguration>();
         loggerMock = Mock.ofType<ContextAwareLogger>();
+        requestValidatorMock = Mock.ofType<ApiRequestValidator>();
         websiteProviderMock = Mock.ofType<WebsiteProvider>();
         pageProviderMock = Mock.ofType<PageProvider>();
         websiteDocumentResponseConverterMock = Mock.ofType<WebsiteDocumentResponseConverter>();
@@ -49,6 +58,7 @@ describe(GetWebsiteController, () => {
         testSubject = new GetWebsiteController(
             serviceConfigMock.object,
             loggerMock.object,
+            requestValidatorMock.object,
             websiteProviderMock.object,
             pageProviderMock.object,
             websiteDocumentResponseConverterMock.object,

--- a/packages/storage-web-api/src/controllers/get-website-controller.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.ts
@@ -5,9 +5,10 @@ import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
 import { ContextAwareLogger } from 'logger';
-import { HttpResponse, WebApiErrorCodes, ApiController, WebsiteProvider, PageProvider, ApiRequestValidator } from 'service-library';
+import { HttpResponse, WebApiErrorCodes, ApiController, WebsiteProvider, PageProvider } from 'service-library';
 import * as StorageDocuments from 'storage-documents';
 import { createWebsiteApiResponse, WebsiteDocumentResponseConverter } from '../converters/website-document-response-converter';
+import { GetWebsiteRequestValidator } from '../request-validators/get-website-request-validator';
 
 @injectable()
 export class GetWebsiteController extends ApiController {
@@ -18,7 +19,7 @@ export class GetWebsiteController extends ApiController {
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
         @inject(ContextAwareLogger) logger: ContextAwareLogger,
-        @inject(ApiRequestValidator) requestValidator: ApiRequestValidator,
+        @inject(GetWebsiteRequestValidator) requestValidator: GetWebsiteRequestValidator,
         @inject(WebsiteProvider) private readonly websiteProvider: WebsiteProvider,
         @inject(PageProvider) private readonly pageProvider: PageProvider,
         private readonly convertWebsiteDocumentToResponse: WebsiteDocumentResponseConverter = createWebsiteApiResponse,

--- a/packages/storage-web-api/src/controllers/get-website-controller.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.ts
@@ -5,7 +5,7 @@ import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
 import { isEmpty } from 'lodash';
 import { ContextAwareLogger } from 'logger';
-import { HttpResponse, WebApiErrorCodes, ApiController, WebsiteProvider, PageProvider } from 'service-library';
+import { HttpResponse, WebApiErrorCodes, ApiController, WebsiteProvider, PageProvider, ApiRequestValidator } from 'service-library';
 import * as StorageDocuments from 'storage-documents';
 import { createWebsiteApiResponse, WebsiteDocumentResponseConverter } from '../converters/website-document-response-converter';
 
@@ -18,11 +18,12 @@ export class GetWebsiteController extends ApiController {
     public constructor(
         @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
         @inject(ContextAwareLogger) logger: ContextAwareLogger,
+        @inject(ApiRequestValidator) requestValidator: ApiRequestValidator,
         @inject(WebsiteProvider) private readonly websiteProvider: WebsiteProvider,
         @inject(PageProvider) private readonly pageProvider: PageProvider,
         private readonly convertWebsiteDocumentToResponse: WebsiteDocumentResponseConverter = createWebsiteApiResponse,
     ) {
-        super(logger);
+        super(logger, requestValidator);
     }
 
     public async handleRequest(): Promise<void> {

--- a/packages/storage-web-api/src/process-web-request.spec.ts
+++ b/packages/storage-web-api/src/process-web-request.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 import { Context } from '@azure/functions';
 import { ServiceConfiguration } from 'common';
 import { Logger } from 'logger';
-import { ApiController } from 'service-library';
+import { ApiController, WebRequestValidator } from 'service-library';
 import { processWebRequest } from './process-web-request';
 
 type TestRequestResponse = {
@@ -20,6 +20,10 @@ class TestableController extends ApiController {
     public readonly apiName = 'test api name';
 
     public readonly logger: Logger;
+
+    protected readonly requestValidator: WebRequestValidator = {
+        validateRequest: (context: Context) => true,
+    };
 
     protected readonly serviceConfig: ServiceConfiguration;
 

--- a/packages/storage-web-api/src/request-validators/get-website-request-validator.spec.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-request-validator.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Context } from '@azure/functions';
+import { HttpResponse, WebApiErrorCodes } from 'service-library';
+import { GetWebsiteRequestValidator } from './get-website-request-validator';
+
+describe(GetWebsiteRequestValidator, () => {
+    const apiVersion = '1.0';
+    let context: Context;
+
+    let testSubject: GetWebsiteRequestValidator;
+
+    beforeEach(() => {
+        context = <Context>(<unknown>{
+            req: {
+                url: 'baseUrl/websites',
+                method: 'GET',
+                headers: {
+                    'content-type': 'application/json',
+                },
+                query: {
+                    'api-version': apiVersion,
+                },
+            },
+        });
+        testSubject = new GetWebsiteRequestValidator();
+    });
+
+    it('rejects invalid api version', () => {
+        context.req.query['api-version'] = 'invalid api version';
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+    });
+});

--- a/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
@@ -6,9 +6,5 @@ import { ApiRequestValidator } from 'service-library';
 
 @injectable()
 export class GetWebsiteRequestValidator extends ApiRequestValidator {
-    public static readonly apiVersions = ['1.0'];
-
-    constructor() {
-        super(GetWebsiteRequestValidator.apiVersions);
-    }
+    protected readonly apiVersions = ['1.0'];
 }

--- a/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { injectable } from 'inversify';
+import { ApiRequestValidator } from 'service-library';
+
+@injectable()
+export class GetWebsiteRequestValidator extends ApiRequestValidator {
+    public static readonly apiVersions = ['1.0'];
+
+    constructor() {
+        super(GetWebsiteRequestValidator.apiVersions);
+    }
+}

--- a/packages/storage-web-api/src/request-validators/post-website-request-validator.spec.ts
+++ b/packages/storage-web-api/src/request-validators/post-website-request-validator.spec.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as ApiContracts from 'api-contracts';
+import { IMock, Mock } from 'typemoq';
+import { Context } from '@azure/functions';
+import { GuidGenerator } from 'common';
+import { HttpResponse, WebApiErrorCodes } from 'service-library';
+import _ from 'lodash';
+import { PostWebsiteRequestValidator } from './post-website-request-validator';
+
+describe(PostWebsiteRequestValidator, () => {
+    let website: ApiContracts.Website;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+    let isValidWebsiteMock: IMock<typeof ApiContracts.isValidWebsiteObject>;
+
+    let testSubject: PostWebsiteRequestValidator;
+
+    beforeEach(() => {
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        isValidWebsiteMock = Mock.ofInstance(() => true);
+        website = _.cloneDeep(ApiContracts.websiteWithRequiredProperties);
+
+        testSubject = new PostWebsiteRequestValidator(guidGeneratorMock.object, isValidWebsiteMock.object);
+    });
+
+    it('rejects invalid api version', () => {
+        const context: Context = createRequestContext('invalid api version');
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+    });
+
+    it('rejects invalid website object', () => {
+        isValidWebsiteMock.setup((v) => v(website)).returns(() => false);
+        const context: Context = createRequestContext();
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.malformedRequest));
+    });
+
+    it('reject website with invalid guid', () => {
+        website.id = 'website id';
+        const context: Context = createRequestContext();
+
+        isValidWebsiteMock.setup((v) => v(website)).returns(() => true);
+        guidGeneratorMock.setup((g) => g.isValidV6Guid(website.id)).returns(() => false);
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.malformedRequest));
+    });
+
+    it('rejects website with pages property', () => {
+        website.pages = [{ id: 'page id', url: 'page url' }];
+        const context: Context = createRequestContext();
+
+        isValidWebsiteMock.setup((v) => v(website)).returns(() => true);
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.malformedRequest));
+    });
+
+    it('accepts valid website with no id', () => {
+        const context: Context = createRequestContext();
+
+        isValidWebsiteMock.setup((v) => v(website)).returns(() => true);
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeTruthy();
+    });
+
+    it('accepts valid website with valid guid', () => {
+        website.id = 'website id';
+        const context: Context = createRequestContext();
+
+        isValidWebsiteMock.setup((v) => v(website)).returns(() => true);
+        guidGeneratorMock.setup((g) => g.isValidV6Guid(website.id)).returns(() => true);
+
+        const isValidRequest = testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeTruthy();
+    });
+
+    function createRequestContext(apiVersion: string = '1.0'): Context {
+        return <Context>(<unknown>{
+            req: {
+                url: 'baseUrl/websites',
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                },
+                query: {
+                    'api-version': apiVersion,
+                },
+                rawBody: JSON.stringify(website),
+            },
+        });
+    }
+});

--- a/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
@@ -10,13 +10,13 @@ import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-lib
 
 @injectable()
 export class PostWebsiteRequestValidator extends ApiRequestValidator {
-    public static readonly apiVersions = ['1.0'];
+    protected readonly apiVersions = ['1.0'];
 
     constructor(
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
         private readonly isValidWebsiteObject: typeof ApiContracts.isValidWebsiteObject = ApiContracts.isValidWebsiteObject,
     ) {
-        super(PostWebsiteRequestValidator.apiVersions);
+        super();
     }
 
     public validateRequest(context: Context): boolean {

--- a/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ApiContracts from 'api-contracts';
+import { Context } from '@azure/functions';
+import { inject } from 'inversify';
+import _ from 'lodash';
+import { GuidGenerator } from 'common';
+import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-library';
+
+export class PostWebsiteRequestValidator extends ApiRequestValidator {
+    public static readonly apiVersions = ['1.0'];
+
+    constructor(
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        private readonly isValidWebsiteObject: typeof ApiContracts.isValidWebsiteObject = ApiContracts.isValidWebsiteObject,
+    ) {
+        super(PostWebsiteRequestValidator.apiVersions);
+    }
+
+    public validateRequest(context: Context): boolean {
+        if (!super.validateRequest(context)) {
+            return false;
+        }
+
+        const payload = this.tryGetPayload<ApiContracts.Website>(context);
+        if (!this.isValidWebsiteObject(payload) || this.hasInvalidId(payload) || this.hasDisallowedProperties(payload)) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.malformedRequest);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private hasInvalidId(website: ApiContracts.Website): boolean {
+        return website.id !== undefined && !this.guidGenerator.isValidV6Guid(website.id);
+    }
+
+    private hasDisallowedProperties(website: ApiContracts.Website): boolean {
+        // Existing page documents will not be updated through this endpoint
+        return website.pages !== undefined;
+    }
+}

--- a/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/post-website-request-validator.ts
@@ -3,11 +3,12 @@
 
 import * as ApiContracts from 'api-contracts';
 import { Context } from '@azure/functions';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import _ from 'lodash';
 import { GuidGenerator } from 'common';
 import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-library';
 
+@injectable()
 export class PostWebsiteRequestValidator extends ApiRequestValidator {
     public static readonly apiVersions = ['1.0'];
 


### PR DESCRIPTION
#### Details

Moved request validation logic into a separate class

##### Motivation

Currently, request validation is performed by the base ApiController class, and base classes must either implement their own separate validation logic or override validateRequest(). Testing validateRequest() overrides can be complicated because this is not a publicly exposed method, and in most cases it also calls the base class's validateRequest(). This change simplifies controller code and tests by keeping validation logic in an easily-mockable object.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
