### PR TITLE
refactor: multiple blob results

### DIFF
--- a/packages/api-contracts/src/test-data/sample-page-scan-data.ts
+++ b/packages/api-contracts/src/test-data/sample-page-scan-data.ts
@@ -24,7 +24,12 @@ export const passedPageScan: PageScan = {
     priority: 1,
     scanStatus: 'pass',
     completedTimestamp: 123456,
-    resultsBlobId: 'passed page results blod id',
+    results: [
+        {
+            blobId: 'results blob id',
+            resultType: 'result type',
+        },
+    ],
     reports: [
         {
             reportId: 'passed page html report id',

--- a/packages/api-contracts/src/types/page-scan.ts
+++ b/packages/api-contracts/src/types/page-scan.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ReportData, ScanStatus } from 'storage-documents';
+import { BlobResultData, ReportData, ScanStatus } from 'storage-documents';
 import { Page } from './page';
 
 export interface PageScan {
@@ -11,7 +11,7 @@ export interface PageScan {
     priority: number;
     scanStatus: ScanStatus;
     completedTimestamp?: number;
-    resultsBlobId?: string;
+    results?: BlobResultData[];
     reports?: ReportData[];
     scanError?: string;
 }

--- a/packages/storage-documents/src/blob-result-data.ts
+++ b/packages/storage-documents/src/blob-result-data.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface BlobResultData {
+    blobId: string;
+    resultType: string;
+    href?: string;
+}

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+export { BlobResultData } from './blob-result-data';
 export { itemTypes, ItemType } from './item-type';
 export { PageScan } from './page-scan';
 export { Page } from './page';

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -5,6 +5,7 @@ import { ReportData } from './report-data';
 import { ScanStatus } from './scan-types';
 import { StorageDocument } from './storage-document';
 import { ItemTypes } from './item-type';
+import { BlobResultData } from './blob-result-data';
 
 /*
  * Represents a scan/crawl of a single URL for one scan type.
@@ -17,7 +18,7 @@ export interface PageScan extends StorageDocument {
     priority: number;
     scanStatus: ScanStatus;
     completedTimestamp?: number;
-    resultsBlobId?: string;
+    results?: BlobResultData[];
     reports?: ReportData[];
     retryCount: number;
     scanError?: string;

--- a/packages/storage-web-api/src/converters/page-scan-document-response-converter.spec.ts
+++ b/packages/storage-web-api/src/converters/page-scan-document-response-converter.spec.ts
@@ -28,6 +28,9 @@ describe(createPageScanApiObject, () => {
         websiteScanId: 'website scan id',
         priority: 0,
         retryCount: 1,
+        completedTimestamp: 1234,
+        results: [{ blobId: 'blob id', resultType: 'test result type' }],
+        reports: [{ reportId: 'report id', format: 'html', href: 'href' }],
         itemType: StorageDocuments.itemTypes.pageScan,
         partitionKey: 'partition key',
     };
@@ -44,6 +47,9 @@ describe(createPageScanApiObject, () => {
             id: pageScanDoc.id,
             page: pageObject,
             scanStatus: pageScanDoc.scanStatus,
+            completedTimestamp: pageScanDoc.completedTimestamp,
+            results: pageScanDoc.results,
+            reports: pageScanDoc.reports,
             priority: 0,
         };
 

--- a/packages/storage-web-api/src/converters/page-scan-document-response-converter.ts
+++ b/packages/storage-web-api/src/converters/page-scan-document-response-converter.ts
@@ -18,7 +18,7 @@ export const createPageScanApiObject = (
         priority: pageScanDocument.priority,
         scanStatus: pageScanDocument.scanStatus,
         completedTimestamp: pageScanDocument.completedTimestamp,
-        resultsBlobId: pageScanDocument.resultsBlobId,
+        results: pageScanDocument.results,
         reports: pageScanDocument.reports,
         scanError: pageScanDocument.scanError,
     };


### PR DESCRIPTION
#### Details

Refactor storage and API types to allow multiple blob results for a page scan.

##### Motivation

Per a comment on #155, complex scans might result in complex combinations of results. This change also allows blob results to follow the same structure as reports.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
