### PR TITLE
Get website scan API endpoint

### DIFF
--- a/packages/api-contracts/src/api-object-validators.ts
+++ b/packages/api-contracts/src/api-object-validators.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { is } from 'typescript-is';
+import { ScanType } from 'storage-documents';
 import { PageUpdate } from './types/page-update';
 import { Website } from './types/website';
 import { WebsiteScanRequest } from './types/website-scan-request';
@@ -18,4 +19,8 @@ export const isValidPageUpdateObject: ApiObjectValidator<PageUpdate> = (obj) => 
 
 export const isValidWebsiteScanRequestObject: ApiObjectValidator<WebsiteScanRequest> = (obj) => {
     return is<WebsiteScanRequest>(obj);
+};
+
+export const isValidScanType: ApiObjectValidator<ScanType> = (scanType) => {
+    return is<ScanType>(scanType);
 };

--- a/packages/integration-tests/tests/api-contracts/validate-scan-type.spec.ts
+++ b/packages/integration-tests/tests/api-contracts/validate-scan-type.spec.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { isValidScanType } from 'api-contracts';
+import { ScanType } from 'storage-documents';
+
+describe(isValidScanType, () => {
+    it.each(['a11y', 'security', 'privacy'])('Returns true for scanType=%s', (scanType) => {
+        expect(isValidScanType(scanType as ScanType)).toBeTruthy();
+    });
+
+    it('returns false for invalid scan type', () => {
+        expect(isValidScanType('invalidType' as ScanType)).toBeFalsy();
+    });
+});

--- a/packages/service-library/src/data-providers/website-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.spec.ts
@@ -130,17 +130,17 @@ describe(WebsiteScanProvider, () => {
     });
 
     describe('readWebsiteScan', () => {
-        it('reads websiteScan with id', async () => {
+        it.each([true, false])('reads websiteScan when throwIfNotSuccess=%s', async (throwIfNotSuccess) => {
             const response = {
                 statusCode: 200,
                 item: websiteScanDoc,
             } as CosmosOperationResponse<WebsiteScan>;
             cosmosContainerClientMock
-                .setup((c) => c.readDocument(websiteScanId, partitionKey))
+                .setup((c) => c.readDocument<WebsiteScan>(websiteScanId, partitionKey, throwIfNotSuccess))
                 .returns(async () => response)
                 .verifiable();
 
-            const actualresponse = await testSubject.readWebsiteScan(websiteScanId);
+            const actualresponse = await testSubject.readWebsiteScan(websiteScanId, throwIfNotSuccess);
 
             expect(actualresponse).toBe(response);
         });
@@ -175,6 +175,74 @@ describe(WebsiteScanProvider, () => {
             const actualIterable = testSubject.getScansForWebsite(websiteId);
 
             expect(actualIterable).toBe(iterableStub);
+        });
+    });
+
+    describe('getLatestScanForWebsite', () => {
+        const scanType = 'a11y';
+        const expectedQuery = {
+            query:
+                'SELECT TOP 1 * FROM c ' +
+                'WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType and c.scanType = @scanType ' +
+                'ORDER BY c._ts DESC',
+            parameters: [
+                {
+                    name: '@websiteId',
+                    value: websiteId,
+                },
+                {
+                    name: '@partitionKey',
+                    value: partitionKey,
+                },
+                {
+                    name: '@itemType',
+                    value: itemTypes.websiteScan,
+                },
+                {
+                    name: '@scanType',
+                    value: scanType,
+                },
+            ],
+        };
+
+        beforeEach(() => {
+            partitionKeyFactoryMock
+                .setup((p) => p.createPartitionKeyForDocument(itemTypes.websiteScan, websiteId))
+                .returns(() => partitionKey);
+        });
+
+        it('returns first result from cosmos query', async () => {
+            const queryResponse: CosmosOperationResponse<WebsiteScan[]> = {
+                statusCode: 200,
+                item: [websiteScanDoc],
+            };
+            cosmosContainerClientMock.setup((c) => c.queryDocuments<WebsiteScan>(expectedQuery)).returns(async () => queryResponse);
+
+            const result = await testSubject.getLatestScanForWebsite(websiteId, scanType);
+
+            expect(result).toEqual(websiteScanDoc);
+        });
+
+        it('returns null if query yields no results', async () => {
+            const queryResponse: CosmosOperationResponse<WebsiteScan[]> = {
+                statusCode: 200,
+                item: [],
+            };
+            cosmosContainerClientMock.setup((c) => c.queryDocuments<WebsiteScan>(expectedQuery)).returns(async () => queryResponse);
+
+            const result = await testSubject.getLatestScanForWebsite(websiteId, scanType);
+
+            expect(result).toBeNull();
+        });
+
+        it('Throws if query fails', () => {
+            const queryResponse: CosmosOperationResponse<WebsiteScan[]> = {
+                statusCode: 500,
+                item: [],
+            };
+            cosmosContainerClientMock.setup((c) => c.queryDocuments<WebsiteScan>(expectedQuery)).returns(async () => queryResponse);
+
+            expect(testSubject.getLatestScanForWebsite(websiteId, scanType)).rejects.toThrow();
         });
     });
 });

--- a/packages/service-library/src/data-providers/website-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.spec.ts
@@ -140,21 +140,9 @@ describe(WebsiteScanProvider, () => {
                 .returns(async () => response)
                 .verifiable();
 
-            const actualWebsiteScan = await testSubject.readWebsiteScan(websiteScanId);
+            const actualresponse = await testSubject.readWebsiteScan(websiteScanId);
 
-            expect(actualWebsiteScan).toBe(websiteScanDoc);
-        });
-
-        it('throws if unsuccessful status code', async () => {
-            const response = {
-                statusCode: 404,
-            } as CosmosOperationResponse<WebsiteScan>;
-            cosmosContainerClientMock
-                .setup((c) => c.readDocument(websiteScanId, partitionKey))
-                .returns(async () => response)
-                .verifiable();
-
-            expect(testSubject.readWebsiteScan(websiteScanId)).rejects.toThrow();
+            expect(actualresponse).toBe(response);
         });
     });
 

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { client, CosmosContainerClient, cosmosContainerClientTypes } from 'azure-services';
+import { CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import { DocumentDataOnly, itemTypes, ScanType, WebsiteScan } from 'storage-documents';
 import { GuidGenerator } from 'common';
@@ -46,11 +46,8 @@ export class WebsiteScanProvider {
         return response.item as WebsiteScan;
     }
 
-    public async readWebsiteScan(id: string): Promise<WebsiteScan> {
-        const response = await this.cosmosContainerClient.readDocument<WebsiteScan>(id, this.getWebsiteScanPartitionKey(id));
-        client.ensureSuccessStatusCode(response);
-
-        return response.item;
+    public async readWebsiteScan(id: string): Promise<CosmosOperationResponse<WebsiteScan>> {
+        return this.cosmosContainerClient.readDocument<WebsiteScan>(id, this.getWebsiteScanPartitionKey(id));
     }
 
     public getScansForWebsite(websiteId: string): CosmosQueryResultsIterable<WebsiteScan> {

--- a/packages/service-library/src/data-providers/website-scan-provider.ts
+++ b/packages/service-library/src/data-providers/website-scan-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
+import { client, CosmosContainerClient, cosmosContainerClientTypes, CosmosOperationResponse } from 'azure-services';
 import { inject, injectable } from 'inversify';
 import { DocumentDataOnly, itemTypes, ScanType, WebsiteScan } from 'storage-documents';
 import { GuidGenerator } from 'common';
@@ -46,8 +46,8 @@ export class WebsiteScanProvider {
         return response.item as WebsiteScan;
     }
 
-    public async readWebsiteScan(id: string): Promise<CosmosOperationResponse<WebsiteScan>> {
-        return this.cosmosContainerClient.readDocument<WebsiteScan>(id, this.getWebsiteScanPartitionKey(id));
+    public async readWebsiteScan(id: string, throwIfNotSuccess: boolean = true): Promise<CosmosOperationResponse<WebsiteScan>> {
+        return this.cosmosContainerClient.readDocument<WebsiteScan>(id, this.getWebsiteScanPartitionKey(id), throwIfNotSuccess);
     }
 
     public getScansForWebsite(websiteId: string): CosmosQueryResultsIterable<WebsiteScan> {
@@ -71,6 +71,43 @@ export class WebsiteScanProvider {
         };
 
         return this.cosmosQueryResultsProvider(this.cosmosContainerClient, query);
+    }
+
+    public async getLatestScanForWebsite(websiteId: string, scanType: ScanType): Promise<WebsiteScan | null> {
+        const partitionKey = this.getWebsiteScanPartitionKey(websiteId);
+        const query = {
+            query:
+                'SELECT TOP 1 * FROM c ' +
+                'WHERE c.partitionKey = @partitionKey and c.websiteId = @websiteId and c.itemType = @itemType and c.scanType = @scanType ' +
+                'ORDER BY c._ts DESC',
+            parameters: [
+                {
+                    name: '@websiteId',
+                    value: websiteId,
+                },
+                {
+                    name: '@partitionKey',
+                    value: partitionKey,
+                },
+                {
+                    name: '@itemType',
+                    value: itemTypes.websiteScan,
+                },
+                {
+                    name: '@scanType',
+                    value: scanType,
+                },
+            ],
+        };
+
+        const response = await this.cosmosContainerClient.queryDocuments<WebsiteScan>(query);
+        client.ensureSuccessStatusCode(response);
+
+        if (response.item.length === 0) {
+            return null;
+        }
+
+        return response.item[0];
     }
 
     private normalizeDbDocument(websiteScan: Partial<WebsiteScan>): Partial<WebsiteScan> {

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -147,7 +147,7 @@ export class WebApiErrorCodes {
         error: {
             code: 'InvalidScanType',
             codeId: 4013,
-            message: 'The scan type must be one of "a11y", "privacy", or "security".',
+            message: 'The scan type must be either a11y, privacy, or security.',
         },
     };
 

--- a/packages/service-library/src/web-api/web-api-error-codes.ts
+++ b/packages/service-library/src/web-api/web-api-error-codes.ts
@@ -16,7 +16,8 @@ export declare type WebApiErrorCodeName =
     | 'UnsupportedApiVersion'
     | 'InvalidFrequencyExpression'
     | 'OutOfRangePriority'
-    | 'MalformedBody';
+    | 'MalformedBody'
+    | 'InvalidScanType';
 
 export interface WebApiErrorCode {
     statusCode: number;
@@ -138,6 +139,15 @@ export class WebApiErrorCodes {
             code: 'InvalidFrequencyExpression',
             codeId: 4012,
             message: 'The frequency is not a valid cron expression.',
+        },
+    };
+
+    public static invalidScanType: WebApiErrorCode = {
+        statusCode: 400,
+        error: {
+            code: 'InvalidScanType',
+            codeId: 4013,
+            message: 'The scan type must be one of "a11y", "privacy", or "security".',
         },
     };
 

--- a/packages/storage-web-api/get-website-scan-func/function.json
+++ b/packages/storage-web-api/get-website-scan-func/function.json
@@ -1,0 +1,18 @@
+{
+    "bindings": [
+        {
+            "authLevel": "anonymous",
+            "name": "request",
+            "type": "httpTrigger",
+            "direction": "in",
+            "route": "websites/{websiteId}/scans/{scanType}/{scanTarget}",
+            "methods": ["get"]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "response"
+        }
+    ],
+    "scriptFile": "../get-website-scan-func/index.js"
+}

--- a/packages/storage-web-api/get-website-scan-func/function.json
+++ b/packages/storage-web-api/get-website-scan-func/function.json
@@ -5,7 +5,7 @@
             "name": "request",
             "type": "httpTrigger",
             "direction": "in",
-            "route": "websites/{websiteId}/scans/{scanType}/{scanTarget}",
+            "route": "websites/{websiteId}/scans/{scanType}/{scanIdOrLatest}",
             "methods": ["get"]
         },
         {

--- a/packages/storage-web-api/get-website-scan-func/index.ts
+++ b/packages/storage-web-api/get-website-scan-func/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { Context } from '@azure/functions';
+import { processWebRequest } from '../src/process-web-request';
+import { GetWebsiteScanController } from '../src/controllers/get-website-scan-controller';
+
+export async function run(context: Context): Promise<void> {
+    await processWebRequest(context, GetWebsiteScanController);
+}

--- a/packages/storage-web-api/post-website-scan-func/function.json
+++ b/packages/storage-web-api/post-website-scan-func/function.json
@@ -5,7 +5,7 @@
             "name": "request",
             "type": "httpTrigger",
             "direction": "in",
-            "route": "scans/websites",
+            "route": "websites/scans",
             "methods": ["post"]
         },
         {

--- a/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.spec.ts
@@ -53,14 +53,6 @@ describe(GetWebsiteController, () => {
         testSubject.context = context;
     });
 
-    it.each([undefined, ''])('Returns invalidResourceId response if websiteId=%s', async (websiteIdValue) => {
-        context.bindingData.websiteId = websiteIdValue;
-
-        await testSubject.handleRequest();
-
-        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
-    });
-
     it('return resourceNotFound response if website doc does not exist', async () => {
         const errorResponse: CosmosOperationResponse<StorageDocuments.Website> = {
             statusCode: 404,

--- a/packages/storage-web-api/src/controllers/get-website-controller.ts
+++ b/packages/storage-web-api/src/controllers/get-website-controller.ts
@@ -3,7 +3,6 @@
 
 import { ServiceConfiguration } from 'common';
 import { inject, injectable } from 'inversify';
-import { isEmpty } from 'lodash';
 import { ContextAwareLogger } from 'logger';
 import { HttpResponse, WebApiErrorCodes, ApiController, WebsiteProvider, PageProvider } from 'service-library';
 import { client } from 'azure-services';
@@ -30,13 +29,6 @@ export class GetWebsiteController extends ApiController {
     public async handleRequest(): Promise<void> {
         const websiteId = <string>this.context.bindingData.websiteId;
         this.logger.setCommonProperties({ source: 'getWebsiteRESTApi', websiteId });
-
-        if (isEmpty(websiteId)) {
-            this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId);
-            this.logger.logError('The client request website id is malformed.');
-
-            return;
-        }
 
         const websiteResponse = await this.websiteProvider.readWebsite(websiteId, false);
         if (websiteResponse.statusCode === 404) {

--- a/packages/storage-web-api/src/controllers/get-website-scan-controller.spec.ts
+++ b/packages/storage-web-api/src/controllers/get-website-scan-controller.spec.ts
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as StorageDocuments from 'storage-documents';
+import * as ApiContracts from 'api-contracts';
+import { IMock, It, Mock } from 'typemoq';
+import { ServiceConfiguration } from 'common';
+import { Logger } from 'logger';
+import { HttpResponse, PageProvider, PageScanProvider, WebApiErrorCodes, WebsiteScanProvider } from 'service-library';
+import { Context } from '@azure/functions';
+import { GetWebsiteScanRequestValidator } from '../request-validators/get-website-scan-request-validator';
+import { WebsiteScanDocumentResponseConverter } from '../converters/website-scan-document-response-converter';
+import { mockCosmosQueryResults } from '../test-utilities/cosmos-query-results-iterable-mock';
+import { GetWebsiteScanController } from './get-website-scan-controller';
+
+describe(GetWebsiteScanController, () => {
+    const websiteId = 'website id';
+    const websiteScanId = 'website scan id';
+    const scanType: StorageDocuments.ScanType = 'a11y';
+    const websiteScanDocument = {
+        id: websiteScanId,
+        websiteId: websiteId,
+        scanType: scanType,
+    } as StorageDocuments.WebsiteScan;
+    const websiteScanResponse = {
+        id: websiteScanId,
+        websiteId: websiteId,
+        scanType: scanType,
+        pageScans: [
+            {
+                id: 'page scan id',
+                page: {
+                    id: 'page id',
+                    url: 'page url',
+                },
+            },
+        ],
+    } as ApiContracts.WebsiteScan;
+
+    let serviceConfigMock: IMock<ServiceConfiguration>;
+    let loggerMock: IMock<Logger>;
+    let requestValidatorMock: IMock<GetWebsiteScanRequestValidator>;
+    let websiteScanProviderMock: IMock<WebsiteScanProvider>;
+    let pageScanProviderMock: IMock<PageScanProvider>;
+    let pageProviderMock: IMock<PageProvider>;
+    let convertWebsiteScanDocumentMock: IMock<WebsiteScanDocumentResponseConverter>;
+
+    let context: Context;
+
+    let testSubject: GetWebsiteScanController;
+
+    beforeEach(() => {
+        serviceConfigMock = Mock.ofType<ServiceConfiguration>();
+        loggerMock = Mock.ofType<Logger>();
+        requestValidatorMock = Mock.ofType<GetWebsiteScanRequestValidator>();
+        websiteScanProviderMock = Mock.ofType<WebsiteScanProvider>();
+        pageScanProviderMock = Mock.ofType<PageScanProvider>();
+        pageProviderMock = Mock.ofType<PageProvider>();
+        convertWebsiteScanDocumentMock = Mock.ofType<WebsiteScanDocumentResponseConverter>();
+
+        context = {
+            bindingData: {
+                websiteId: websiteId,
+                scanTarget: websiteScanId,
+                scanType: scanType,
+            },
+        } as unknown as Context;
+
+        testSubject = new GetWebsiteScanController(
+            serviceConfigMock.object,
+            loggerMock.object,
+            requestValidatorMock.object,
+            websiteScanProviderMock.object,
+            pageScanProviderMock.object,
+            pageProviderMock.object,
+            convertWebsiteScanDocumentMock.object,
+        );
+        testSubject.context = context;
+    });
+
+    it('returns resourceNotFound if cosmos returns 404 for specific scan id', async () => {
+        const cosmosResponse = { statusCode: 404 };
+
+        websiteScanProviderMock.setup((wsp) => wsp.readWebsiteScan(websiteScanId)).returns(async () => cosmosResponse);
+
+        await testSubject.handleRequest();
+
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.resourceNotFound));
+    });
+
+    it('returns internalError if cosmos returns a different error code for specific scan id', async () => {
+        const cosmosResponse = { statusCode: 500 };
+
+        websiteScanProviderMock.setup((wsp) => wsp.readWebsiteScan(websiteScanId)).returns(async () => cosmosResponse);
+
+        await testSubject.handleRequest();
+
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.internalError));
+    });
+
+    it('returns website scan with specific id', async () => {
+        const pageScansIterableMock = mockCosmosQueryResults<StorageDocuments.PageScan>([]);
+        const cosmosResponse = { statusCode: 200, item: websiteScanDocument };
+
+        websiteScanProviderMock.setup((wsp) => wsp.readWebsiteScan(websiteScanId)).returns(async () => cosmosResponse);
+        pageScanProviderMock.setup((psp) => psp.getAllPageScansForWebsiteScan(websiteScanId)).returns(() => pageScansIterableMock.object);
+        convertWebsiteScanDocumentMock
+            .setup((c) => c(websiteScanDocument, pageScansIterableMock.object, It.isAny()))
+            .returns(async () => websiteScanResponse);
+
+        await testSubject.handleRequest();
+
+        expect(context.res.statusCode).toBe(200);
+        expect(context.res.body).toEqual(websiteScanResponse);
+    });
+});

--- a/packages/storage-web-api/src/controllers/get-website-scan-controller.spec.ts
+++ b/packages/storage-web-api/src/controllers/get-website-scan-controller.spec.ts
@@ -10,7 +10,7 @@ import { ServiceConfiguration } from 'common';
 import { Logger } from 'logger';
 import { HttpResponse, PageProvider, PageScanProvider, WebApiErrorCodes, WebsiteScanProvider } from 'service-library';
 import { Context } from '@azure/functions';
-import { GetWebsiteScanRequestValidator, latestScanTarget } from '../request-validators/get-website-scan-request-validator';
+import { GetWebsiteScanRequestValidator, latestScanTag } from '../request-validators/get-website-scan-request-validator';
 import { WebsiteScanDocumentResponseConverter } from '../converters/website-scan-document-response-converter';
 import { mockCosmosQueryResults } from '../test-utilities/cosmos-query-results-iterable-mock';
 import { GetWebsiteScanController } from './get-website-scan-controller';
@@ -87,7 +87,7 @@ describe(GetWebsiteScanController, () => {
 
     describe('With specific scan id', () => {
         beforeEach(() => {
-            context.bindingData.scanTarget = websiteScanId;
+            context.bindingData.scanIdOrLatest = websiteScanId;
         });
 
         it('returns resourceNotFound if cosmos returns 404', async () => {
@@ -129,9 +129,9 @@ describe(GetWebsiteScanController, () => {
         });
     });
 
-    describe('with scanTarget=latest', () => {
+    describe('with scanIdOrLatest=latest', () => {
         beforeEach(() => {
-            context.bindingData.scanTarget = latestScanTarget;
+            context.bindingData.scanIdOrLatest = latestScanTag;
         });
 
         it('returns resourceNotFound if no scan is found', async () => {

--- a/packages/storage-web-api/src/controllers/get-website-scan-controller.ts
+++ b/packages/storage-web-api/src/controllers/get-website-scan-controller.ts
@@ -33,7 +33,7 @@ export class GetWebsiteScanController extends ApiController {
         const scanTarget = this.context.bindingData.scanTarget;
         const scanType = this.context.bindingData.scanType as StorageDocuments.ScanType;
 
-        this.logger.setCommonProperties({ source: 'getWebsiteScanRESTApi', websiteId });
+        this.logger.setCommonProperties({ source: 'getWebsiteScanRESTApi', websiteId, scanType, scanTarget });
 
         let websiteScanDocument: StorageDocuments.WebsiteScan | null;
         if (scanTarget === latestScanTarget) {

--- a/packages/storage-web-api/src/controllers/get-website-scan-controller.ts
+++ b/packages/storage-web-api/src/controllers/get-website-scan-controller.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as StorageDocuments from 'storage-documents';
+import { ServiceConfiguration } from 'common';
+import { inject, injectable } from 'inversify';
+import { ContextAwareLogger } from 'logger';
+import { ApiController, HttpResponse, PageProvider, PageScanProvider, WebApiErrorCodes, WebsiteScanProvider } from 'service-library';
+import { client } from 'azure-services';
+import { GetWebsiteRequestValidator } from '../request-validators/get-website-request-validator';
+import { GetWebsiteScanRequestValidator, latestScanTarget } from '../request-validators/get-website-scan-request-validator';
+import { createWebsiteScanApiResponse, WebsiteScanDocumentResponseConverter } from '../converters/website-scan-document-response-converter';
+
+@injectable()
+export class GetWebsiteScanController extends ApiController {
+    public readonly apiVersion = '1.0';
+
+    public readonly apiName = 'storage-web-api-get-website-scan';
+
+    public constructor(
+        @inject(ServiceConfiguration) protected readonly serviceConfig: ServiceConfiguration,
+        @inject(ContextAwareLogger) logger: ContextAwareLogger,
+        @inject(GetWebsiteRequestValidator) requestValidator: GetWebsiteScanRequestValidator,
+        @inject(WebsiteScanProvider) private readonly websiteScanProvider: WebsiteScanProvider,
+        @inject(PageScanProvider) private readonly pageScanProvider: PageScanProvider,
+        @inject(PageProvider) private readonly pageProvider: PageProvider, // TODO: make converter an object and inject this into that
+        private readonly convertWebsiteScanDocumentToResponse: WebsiteScanDocumentResponseConverter = createWebsiteScanApiResponse,
+    ) {
+        super(logger, requestValidator);
+    }
+
+    public async handleRequest(): Promise<void> {
+        const websiteId = this.context.bindingData.websiteId;
+        const scanTarget = this.context.bindingData.scanTarget;
+        const scanType = this.context.bindingData.scanType as StorageDocuments.ScanType;
+
+        this.logger.setCommonProperties({ source: 'getWebsiteRESTApi', websiteId });
+
+        let websiteScanDocument: StorageDocuments.WebsiteScan | null;
+        if (scanTarget === latestScanTarget) {
+            websiteScanDocument = await this.getLatestWebsiteScan(websiteId, scanType);
+        } else {
+            websiteScanDocument = await this.getScanWithId(scanTarget);
+        }
+
+        if (websiteScanDocument === null) {
+            return;
+        }
+
+        this.logger.setCommonProperties({ websiteScanId: websiteScanDocument.id });
+
+        const pageScanIterable = this.pageScanProvider.getAllPageScansForWebsiteScan(websiteScanDocument.id);
+
+        const getPageForScan = (pageScan: StorageDocuments.PageScan) => this.pageProvider.readPage(pageScan.pageId);
+        const websiteScanResponseObj = await this.convertWebsiteScanDocumentToResponse(
+            websiteScanDocument,
+            pageScanIterable,
+            getPageForScan,
+        );
+
+        this.context.res = {
+            statusCode: 200,
+            body: websiteScanResponseObj,
+        };
+    }
+
+    private async getScanWithId(scanId: string): Promise<StorageDocuments.WebsiteScan | null> {
+        const websiteDocumentResponse = await this.websiteScanProvider.readWebsiteScan(scanId);
+        if (!client.isSuccessStatusCode(websiteDocumentResponse)) {
+            if (websiteDocumentResponse.statusCode === 404) {
+                this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.resourceNotFound);
+                this.logger.logError('Website scan document not found');
+            } else {
+                this.context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.internalError);
+                this.logger.logError('Error reading websiteScan document', { statusCode: `${websiteDocumentResponse.statusCode}` });
+            }
+
+            return null;
+        } else {
+            return websiteDocumentResponse.item;
+        }
+    }
+
+    private async getLatestWebsiteScan(
+        websiteId: string,
+        scanType: StorageDocuments.ScanType,
+    ): Promise<StorageDocuments.WebsiteScan | null> {
+        return null; //TODO: implement
+    }
+}

--- a/packages/storage-web-api/src/converters/website-scan-document-response-converter.spec.ts
+++ b/packages/storage-web-api/src/converters/website-scan-document-response-converter.spec.ts
@@ -7,14 +7,14 @@ import * as ApiContracts from 'api-contracts';
 import * as StorageDocuments from 'storage-documents';
 import _ from 'lodash';
 import { IMock, Mock } from 'typemoq';
-import { CosmosQueryResultsIterable, PageProvider } from 'service-library';
+import { CosmosQueryResultsIterable } from 'service-library';
 import { mockCosmosQueryResults } from '../test-utilities/cosmos-query-results-iterable-mock';
 import { createWebsiteScanApiResponse } from './website-scan-document-response-converter';
 import { PageScanDocumentResponseConverter } from './page-scan-document-response-converter';
 
 describe(createWebsiteScanApiResponse, () => {
     let websiteScanDocument: StorageDocuments.WebsiteScan;
-    let pageProviderMock: IMock<PageProvider>;
+    let getPageForScanMock: IMock<(pageScan: StorageDocuments.PageScan) => Promise<StorageDocuments.Page>>;
     let createPageScanObjectMock: IMock<PageScanDocumentResponseConverter>;
 
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe(createWebsiteScanApiResponse, () => {
             partitionKey: 'partition key',
         };
 
-        pageProviderMock = Mock.ofType<PageProvider>();
+        getPageForScanMock = Mock.ofInstance(() => null);
         createPageScanObjectMock = Mock.ofType<PageScanDocumentResponseConverter>();
     });
 
@@ -48,8 +48,8 @@ describe(createWebsiteScanApiResponse, () => {
             expect(
                 await createWebsiteScanApiResponse(
                     websiteScanDocument,
-                    pageProviderMock.object,
                     pageScansIterable.object,
+                    getPageForScanMock.object,
                     createPageScanObjectMock.object,
                 ),
             ).toEqual(expectedResponse);
@@ -61,8 +61,8 @@ describe(createWebsiteScanApiResponse, () => {
             expect(
                 await createWebsiteScanApiResponse(
                     websiteScanDocument,
-                    pageProviderMock.object,
                     pageScansIterable.object,
+                    getPageForScanMock.object,
                     createPageScanObjectMock.object,
                 ),
             ).toEqual(expectedResponse);
@@ -91,7 +91,7 @@ describe(createWebsiteScanApiResponse, () => {
                     itemType: StorageDocuments.itemTypes.page,
                 } as StorageDocuments.Page;
 
-                pageProviderMock.setup((pp) => pp.readPage(page.id)).returns(async () => pageDocument);
+                getPageForScanMock.setup((gp) => gp(pageScanDocument)).returns(async () => pageDocument);
                 createPageScanObjectMock.setup((c) => c(pageScanDocument, pageDocument)).returns(() => pageScanObject);
             });
 

--- a/packages/storage-web-api/src/converters/website-scan-document-response-converter.ts
+++ b/packages/storage-web-api/src/converters/website-scan-document-response-converter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { CosmosQueryResultsIterable, PageProvider } from 'service-library';
+import { CosmosQueryResultsIterable } from 'service-library';
 import * as StorageDocuments from 'storage-documents';
 import * as ApiContracts from 'api-contracts';
 import { createPageScanApiObject, PageScanDocumentResponseConverter } from './page-scan-document-response-converter';
@@ -10,8 +10,8 @@ export type WebsiteScanDocumentResponseConverter = typeof createWebsiteScanApiRe
 
 export const createWebsiteScanApiResponse = async (
     websiteScanDocument: StorageDocuments.WebsiteScan,
-    pageProvider?: PageProvider,
     pageScansIterable?: CosmosQueryResultsIterable<StorageDocuments.PageScan>,
+    getPageForScan?: (pageScan: StorageDocuments.PageScan) => Promise<StorageDocuments.Page>,
     createPageScanObject: PageScanDocumentResponseConverter = createPageScanApiObject,
 ): Promise<ApiContracts.WebsiteScan> => {
     const websiteScanApiObject: ApiContracts.WebsiteScan = {
@@ -25,11 +25,11 @@ export const createWebsiteScanApiResponse = async (
         reports: websiteScanDocument.reports,
     };
 
-    if (pageScansIterable !== undefined && pageProvider !== undefined) {
+    if (pageScansIterable !== undefined && getPageForScan !== undefined) {
         websiteScanApiObject.pageScans = [];
         for await (const pageScan of pageScansIterable) {
             if (pageScan !== undefined) {
-                const page = await pageProvider.readPage(pageScan.pageId);
+                const page = await getPageForScan(pageScan);
                 const pageScanObject = createPageScanObject(pageScan, page);
                 websiteScanApiObject.pageScans.push(pageScanObject);
             }

--- a/packages/storage-web-api/src/request-validators/get-website-request-validator.spec.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-request-validator.spec.ts
@@ -5,15 +5,20 @@ import 'reflect-metadata';
 
 import { Context } from '@azure/functions';
 import { HttpResponse, WebApiErrorCodes } from 'service-library';
+import { GuidGenerator } from 'common';
+import { IMock, Mock } from 'typemoq';
 import { GetWebsiteRequestValidator } from './get-website-request-validator';
 
 describe(GetWebsiteRequestValidator, () => {
     const apiVersion = '1.0';
+    const websiteId = 'website id';
     let context: Context;
+    let guidGeneratorMock: IMock<GuidGenerator>;
 
     let testSubject: GetWebsiteRequestValidator;
 
     beforeEach(() => {
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
         context = <Context>(<unknown>{
             req: {
                 url: 'baseUrl/websites',
@@ -25,16 +30,47 @@ describe(GetWebsiteRequestValidator, () => {
                     'api-version': apiVersion,
                 },
             },
+            bindingData: {
+                websiteId: websiteId,
+            },
         });
-        testSubject = new GetWebsiteRequestValidator();
+        testSubject = new GetWebsiteRequestValidator(guidGeneratorMock.object);
     });
 
     it('rejects invalid api version', async () => {
         context.req.query['api-version'] = 'invalid api version';
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(websiteId)).returns(() => true);
 
         const isValidRequest = await testSubject.validateRequest(context);
 
         expect(isValidRequest).toBeFalsy();
         expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+    });
+
+    it('rejects empty website id', async () => {
+        context.bindingData.websiteId = '';
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(websiteId)).returns(() => true);
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('rejects invalid website guid', async () => {
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(websiteId)).returns(() => false);
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('accepts request with valid guid', async () => {
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(websiteId)).returns(() => true);
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeTruthy();
     });
 });

--- a/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-request-validator.ts
@@ -1,10 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
-import { ApiRequestValidator } from 'service-library';
+import { Context } from '@azure/functions';
+import { inject, injectable } from 'inversify';
+import _ from 'lodash';
+import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-library';
+import { GuidGenerator } from 'common';
 
 @injectable()
 export class GetWebsiteRequestValidator extends ApiRequestValidator {
     protected readonly apiVersions = ['1.0'];
+
+    constructor(@inject(GuidGenerator) private readonly guidGenerator: GuidGenerator) {
+        super();
+    }
+
+    public async validateRequest(context: Context): Promise<boolean> {
+        if (!(await super.validateRequest(context))) {
+            return false;
+        }
+
+        const websiteId = context.bindingData.websiteId as string;
+        if (_.isEmpty(websiteId) || !this.guidGenerator.isValidV6Guid(websiteId)) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId);
+
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.spec.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.spec.ts
@@ -10,7 +10,7 @@ import { HttpResponse, WebApiErrorCodes } from 'service-library';
 import { GuidGenerator } from 'common';
 import { IMock, Mock } from 'typemoq';
 import { ScanType } from 'storage-documents';
-import { GetWebsiteScanRequestValidator, latestScanTarget } from './get-website-scan-request-validator';
+import { GetWebsiteScanRequestValidator, latestScanTag } from './get-website-scan-request-validator';
 
 describe(GetWebsiteScanRequestValidator, () => {
     const apiVersion = '1.0';
@@ -43,7 +43,7 @@ describe(GetWebsiteScanRequestValidator, () => {
             bindingData: {
                 websiteId: websiteId,
                 scanType: scanType,
-                scanTarget: scanId,
+                scanIdOrLatest: scanId,
             },
         });
         websiteIdIsValid = true;
@@ -84,7 +84,7 @@ describe(GetWebsiteScanRequestValidator, () => {
     });
 
     it('rejects empty scan id', async () => {
-        context.bindingData.scanTarget = '';
+        context.bindingData.scanIdOrLatest = '';
 
         const isValidRequest = await testSubject.validateRequest(context);
 
@@ -117,7 +117,7 @@ describe(GetWebsiteScanRequestValidator, () => {
     });
 
     it('accepts request with scan target="latest" and valid scan type', async () => {
-        context.bindingData.scanTarget = latestScanTarget;
+        context.bindingData.scanIdOrLatest = latestScanTag;
 
         const isValidRequest = await testSubject.validateRequest(context);
 

--- a/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.spec.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.spec.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as ApiContracts from 'api-contracts';
+import * as StorageDocuments from 'storage-documents';
+import { Context } from '@azure/functions';
+import { HttpResponse, WebApiErrorCodes } from 'service-library';
+import { GuidGenerator } from 'common';
+import { IMock, Mock } from 'typemoq';
+import { ScanType } from 'storage-documents';
+import { GetWebsiteScanRequestValidator, latestScanTarget } from './get-website-scan-request-validator';
+
+describe(GetWebsiteScanRequestValidator, () => {
+    const apiVersion = '1.0';
+    const websiteId = 'website id';
+    const scanType = 'scan type' as StorageDocuments.ScanType;
+    const scanId = 'scan id';
+    let context: Context;
+    let guidGeneratorMock: IMock<GuidGenerator>;
+    let isValidScanTypeMock: IMock<ApiContracts.ApiObjectValidator<ScanType>>;
+    let websiteIdIsValid: boolean;
+    let scanIdIsValid: boolean;
+    let scanTypeIsValid: boolean;
+
+    let testSubject: GetWebsiteScanRequestValidator;
+
+    beforeEach(() => {
+        guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        isValidScanTypeMock = Mock.ofInstance(() => null);
+        context = <Context>(<unknown>{
+            req: {
+                url: 'baseUrl/websites',
+                method: 'GET',
+                headers: {
+                    'content-type': 'application/json',
+                },
+                query: {
+                    'api-version': apiVersion,
+                },
+            },
+            bindingData: {
+                websiteId: websiteId,
+                scanType: scanType,
+                scanTarget: scanId,
+            },
+        });
+        websiteIdIsValid = true;
+        scanIdIsValid = true;
+        scanTypeIsValid = true;
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(websiteId)).returns(() => websiteIdIsValid);
+        guidGeneratorMock.setup((gg) => gg.isValidV6Guid(scanId)).returns(() => scanIdIsValid);
+        isValidScanTypeMock.setup((o) => o(scanType)).returns(() => scanTypeIsValid);
+
+        testSubject = new GetWebsiteScanRequestValidator(guidGeneratorMock.object, isValidScanTypeMock.object);
+    });
+
+    it('rejects invalid api version', async () => {
+        context.req.query['api-version'] = 'invalid api version';
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.unsupportedApiVersion));
+    });
+
+    it('rejects empty website id', async () => {
+        context.bindingData.websiteId = '';
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('rejects invalid website guid', async () => {
+        websiteIdIsValid = false;
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('rejects empty scan id', async () => {
+        context.bindingData.scanTarget = '';
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('rejects invalid scan guid', async () => {
+        scanIdIsValid = false;
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId));
+    });
+
+    it('rejects invalid scan type', async () => {
+        scanTypeIsValid = false;
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeFalsy();
+        expect(context.res).toEqual(HttpResponse.getErrorResponse(WebApiErrorCodes.invalidScanType));
+    });
+
+    it('accepts request with valid guids and scan type', async () => {
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeTruthy();
+    });
+
+    it('accepts request with scan target="latest" and valid scan type', async () => {
+        context.bindingData.scanTarget = latestScanTarget;
+
+        const isValidRequest = await testSubject.validateRequest(context);
+
+        expect(isValidRequest).toBeTruthy();
+    });
+});

--- a/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.ts
@@ -9,7 +9,7 @@ import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-lib
 import _ from 'lodash';
 import { GuidGenerator } from 'common';
 
-export const latestScanTarget = 'latest';
+export const latestScanTag = 'latest';
 
 @injectable()
 export class GetWebsiteScanRequestValidator extends ApiRequestValidator {
@@ -28,10 +28,10 @@ export class GetWebsiteScanRequestValidator extends ApiRequestValidator {
         }
 
         const websiteId = <string>context.bindingData.websiteId;
-        const scanTarget = <string>context.bindingData.scanTarget;
+        const scanIdOrLatest = <string>context.bindingData.scanIdOrLatest;
         const scanType = <StorageDocuments.ScanType>context.bindingData.scanType;
 
-        if (this.isInvalidWebsiteId(websiteId) || this.isInvalidScanTarget(scanTarget)) {
+        if (this.isInvalidWebsiteId(websiteId) || this.isInvalidScanTarget(scanIdOrLatest)) {
             context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId);
 
             return false;
@@ -50,7 +50,7 @@ export class GetWebsiteScanRequestValidator extends ApiRequestValidator {
         return _.isEmpty(websiteId) || !this.guidGenerator.isValidV6Guid(websiteId);
     }
 
-    private isInvalidScanTarget(scanTarget: string): boolean {
-        return _.isEmpty(scanTarget) || (!this.guidGenerator.isValidV6Guid(scanTarget) && scanTarget !== latestScanTarget);
+    private isInvalidScanTarget(scanIdOrLatest: string): boolean {
+        return _.isEmpty(scanIdOrLatest) || (!this.guidGenerator.isValidV6Guid(scanIdOrLatest) && scanIdOrLatest !== latestScanTag);
     }
 }

--- a/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.ts
+++ b/packages/storage-web-api/src/request-validators/get-website-scan-request-validator.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ApiContracts from 'api-contracts';
+import * as StorageDocuments from 'storage-documents';
+import { Context } from '@azure/functions';
+import { inject, injectable } from 'inversify';
+import { ApiRequestValidator, HttpResponse, WebApiErrorCodes } from 'service-library';
+import _ from 'lodash';
+import { GuidGenerator } from 'common';
+
+export const latestScanTarget = 'latest';
+
+@injectable()
+export class GetWebsiteScanRequestValidator extends ApiRequestValidator {
+    protected readonly apiVersions = ['1.0'];
+
+    constructor(
+        @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        private readonly isValidScanType: ApiContracts.ApiObjectValidator<StorageDocuments.ScanType> = ApiContracts.isValidScanType,
+    ) {
+        super();
+    }
+
+    public async validateRequest(context: Context): Promise<boolean> {
+        if (!(await super.validateRequest(context))) {
+            return false;
+        }
+
+        const websiteId = <string>context.bindingData.websiteId;
+        const scanTarget = <string>context.bindingData.scanTarget;
+        const scanType = <StorageDocuments.ScanType>context.bindingData.scanType;
+
+        if (this.isInvalidWebsiteId(websiteId) || this.isInvalidScanTarget(scanTarget)) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidResourceId);
+
+            return false;
+        }
+
+        if (!this.isValidScanType(scanType)) {
+            context.res = HttpResponse.getErrorResponse(WebApiErrorCodes.invalidScanType);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private isInvalidWebsiteId(websiteId: string): boolean {
+        return _.isEmpty(websiteId) || !this.guidGenerator.isValidV6Guid(websiteId);
+    }
+
+    private isInvalidScanTarget(scanTarget: string): boolean {
+        return _.isEmpty(scanTarget) || (!this.guidGenerator.isValidV6Guid(scanTarget) && scanTarget !== latestScanTarget);
+    }
+}

--- a/packages/storage-web-api/webpack.config.js
+++ b/packages/storage-web-api/webpack.config.js
@@ -18,6 +18,10 @@ module.exports = (env) => {
         externals: ['@azure/functions'],
         entry: {
             ['get-website-func']: path.resolve('./get-website-func/index.ts'),
+            ['post-website-func']: path.resolve('./post-website-func/index.ts'),
+            ['post-page-func']: path.resolve('./post-page-func/index.ts'),
+            ['get-website-scan-func']: path.resolve('./get-website-scan-func/index.ts'),
+            ['post-website-scan-func']: path.resolve('./post-website-scan-func/index.ts'),
         },
         mode: 'development',
         module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,14 +2925,6 @@
     "@typescript-eslint/typescript-estree" "4.29.0"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz#6a3009d2ab64a30fc8a1e257a1a320067f36a0ce"
-  integrity sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==
-  dependencies:
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/visitor-keys" "4.28.0"
-
 "@typescript-eslint/scope-manager@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz#cf5474f87321bedf416ef65839b693bddd838599"
@@ -2941,28 +2933,10 @@
     "@typescript-eslint/types" "4.29.0"
     "@typescript-eslint/visitor-keys" "4.29.0"
 
-"@typescript-eslint/types@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.0.tgz#a33504e1ce7ac51fc39035f5fe6f15079d4dafb0"
-  integrity sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==
-
 "@typescript-eslint/types@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
   integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
-
-"@typescript-eslint/typescript-estree@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz#e66d4e5aa2ede66fec8af434898fe61af10c71cf"
-  integrity sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==
-  dependencies:
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/visitor-keys" "4.28.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.29.0":
   version "4.29.0"
@@ -2976,14 +2950,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz#255c67c966ec294104169a6939d96f91c8a89434"
-  integrity sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==
-  dependencies:
-    "@typescript-eslint/types" "4.28.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.29.0":
   version "4.29.0"


### PR DESCRIPTION
#### Details

Adds an endpoint to get website scan status. The caller can either retrieve a website scan with a specific id or the latest scan for a website of a given type. The API also retrieves information about page scans related to the requested website scan.

##### Motivation

Allow access to individual website scan results

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
