### PR TITLE
AAD and network isolation for CosmosDB

### DIFF
--- a/packages/azure-services/src/credentials/credentials-provider.spec.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.spec.ts
@@ -1,34 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { DefaultAzureCredential } from '@azure/identity';
 import 'reflect-metadata';
 
-import { IMock, Mock, Times } from 'typemoq';
 import { CredentialsProvider } from './credentials-provider';
-import { MSICredentialsProvider } from './msi-credential-provider';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe(CredentialsProvider, () => {
-    let testSubject: CredentialsProvider;
-    let msiCredProviderMock: IMock<MSICredentialsProvider>;
-    const credentialsStub = 'test credentials' as any;
+    it('gets default credentials with MSI auth', async () => {
+        const testSubject = new CredentialsProvider();
 
-    beforeEach(() => {
-        msiCredProviderMock = Mock.ofType(MSICredentialsProvider);
-    });
+        const actualCredentials = await testSubject.getDefaultTokenCredential();
 
-    it('gets batch credentials with MSI auth', async () => {
-        testSubject = new CredentialsProvider(msiCredProviderMock.object);
-
-        msiCredProviderMock
-            .setup(async (r) => r.getCredentials('https://batch.core.windows.net/'))
-            .returns(async () => Promise.resolve(credentialsStub))
-            .verifiable(Times.once());
-
-        const actualCredentials = await testSubject.getCredentialsForBatch();
-
-        expect(actualCredentials).toBe(credentialsStub);
-        msiCredProviderMock.verifyAll();
+        expect(actualCredentials).toBeInstanceOf(DefaultAzureCredential);
     });
 });

--- a/packages/azure-services/src/credentials/credentials-provider.ts
+++ b/packages/azure-services/src/credentials/credentials-provider.ts
@@ -1,20 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
-import { Credentials, MSICredentialsProvider } from './msi-credential-provider';
+import { DefaultAzureCredential, TokenCredential } from '@azure/identity';
+import { injectable } from 'inversify';
 
 @injectable()
 export class CredentialsProvider {
-    constructor(@inject(MSICredentialsProvider) private readonly msiCredentialProvider: MSICredentialsProvider) {}
-
-    public async getCredentialsForBatch(): Promise<Credentials> {
-        // eslint-disable-next-line max-len
-        // referred https://docs.microsoft.com/en-us/rest/api/batchservice/authenticate-requests-to-the-azure-batch-service#authentication-via-azure-ad
-        return this.getCredentialsForResource('https://batch.core.windows.net/');
-    }
-
-    private async getCredentialsForResource(resource: string): Promise<Credentials> {
-        return this.msiCredentialProvider.getCredentials(resource);
+    public getDefaultTokenCredential(): TokenCredential {
+        return new DefaultAzureCredential();
     }
 }

--- a/packages/azure-services/src/key-vault/secret-names.ts
+++ b/packages/azure-services/src/key-vault/secret-names.ts
@@ -3,7 +3,6 @@
 
 export const secretNames = {
     cosmosDbUrl: 'cosmosDbUrl',
-    cosmosDbArmUrl: 'cosmosDbArmUrl',
     storageAccountName: 'storageAccountName',
     storageAccountKey: 'storageAccountKey',
     appInsightsApiKey: 'appInsightsApiKey',

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -154,7 +154,6 @@ describe(registerAzureServicesToContainer, () => {
     describe('CosmosClientProvider', () => {
         let secretProviderMock: IMock<SecretProvider>;
         const cosmosDbUrl = 'db url';
-        const cosmosDbArmUrl = 'db arm url';
         const cosmosDbKey = 'db key';
         const expectedOptions = { endpoint: cosmosDbUrl, key: cosmosDbKey };
         let cosmosKeyProviderMock: IMock<CosmosKeyProvider>;
@@ -167,12 +166,6 @@ describe(registerAzureServicesToContainer, () => {
                 .setup(async (s) => s.getSecret(secretNames.cosmosDbUrl))
                 .returns(async () => Promise.resolve(cosmosDbUrl))
                 .verifiable();
-            secretProviderMock
-                .setup(async (s) => s.getSecret(secretNames.cosmosDbArmUrl))
-                .returns(async () => Promise.resolve(cosmosDbArmUrl))
-                .verifiable();
-
-            cosmosKeyProviderMock.setup((ckp) => ckp.getCosmosKey(cosmosDbArmUrl)).returns(async () => cosmosDbKey);
         });
 
         afterEach(() => {
@@ -205,7 +198,6 @@ describe(registerAzureServicesToContainer, () => {
         it('use env variables if available', async () => {
             secretProviderMock.reset();
             secretProviderMock.setup(async (s) => s.getSecret(secretNames.cosmosDbUrl)).verifiable(Times.never());
-            secretProviderMock.setup(async (s) => s.getSecret(secretNames.cosmosDbArmUrl)).verifiable(Times.never());
             process.env.COSMOS_DB_URL = cosmosDbUrl;
             process.env.COSMOS_DB_KEY = cosmosDbKey;
 

--- a/packages/azure-services/src/register-azure-services-to-container.spec.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.spec.ts
@@ -11,6 +11,7 @@ import { ContextAwareLogger, registerLoggerToContainer } from 'logger';
 import { IMock, Mock, Times } from 'typemoq';
 import { SecretClient } from '@azure/keyvault-secrets';
 import { QueueServiceClient } from '@azure/storage-queue';
+import { TokenCredential } from '@azure/identity';
 import { CosmosClientWrapper } from './azure-cosmos/cosmos-client-wrapper';
 import { Queue } from './azure-queue/queue';
 import { StorageConfig } from './azure-queue/storage-config';
@@ -153,14 +154,16 @@ describe(registerAzureServicesToContainer, () => {
 
     describe('CosmosClientProvider', () => {
         let secretProviderMock: IMock<SecretProvider>;
+        let credentialsProviderMock: IMock<CredentialsProvider>;
         const cosmosDbUrl = 'db url';
         const cosmosDbKey = 'db key';
-        const expectedOptions = { endpoint: cosmosDbUrl, key: cosmosDbKey };
+
         let cosmosKeyProviderMock: IMock<CosmosKeyProvider>;
 
         beforeEach(() => {
             secretProviderMock = Mock.ofType(SecretProvider);
             cosmosKeyProviderMock = Mock.ofType(CosmosKeyProvider);
+            credentialsProviderMock = Mock.ofType(CredentialsProvider);
 
             secretProviderMock
                 .setup(async (s) => s.getSecret(secretNames.cosmosDbUrl))
@@ -174,13 +177,19 @@ describe(registerAzureServicesToContainer, () => {
         });
 
         it('verify CosmosClientProvider resolution', async () => {
+            const testCredential = {} as TokenCredential;
+            const expectedOptions = { endpoint: cosmosDbUrl, aadCredentials: testCredential };
+
+            credentialsProviderMock.setup((cp) => cp.getDefaultTokenCredential()).returns(() => testCredential);
+
             runCosmosClientTest(container, secretProviderMock, cosmosKeyProviderMock);
+            stubBinding(container, CredentialsProvider, credentialsProviderMock.object);
 
             const expectedCosmosClient = cosmosClientFactoryStub(expectedOptions);
             const cosmosClientProvider = container.get<CosmosClientProvider>(iocTypeNames.CosmosClientProvider);
             const cosmosClient = await cosmosClientProvider();
 
-            expect(cosmosClient).toEqual(expectedCosmosClient);
+            expect(cosmosClient).toMatchObject(expectedCosmosClient);
         });
 
         it('creates singleton queueService instance', async () => {
@@ -196,6 +205,7 @@ describe(registerAzureServicesToContainer, () => {
         });
 
         it('use env variables if available', async () => {
+            const expectedOptions = { endpoint: cosmosDbUrl, key: cosmosDbKey };
             secretProviderMock.reset();
             secretProviderMock.setup(async (s) => s.getSecret(secretNames.cosmosDbUrl)).verifiable(Times.never());
             process.env.COSMOS_DB_URL = cosmosDbUrl;

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -8,7 +8,6 @@ import { QueueServiceClient } from '@azure/storage-queue';
 import { IoC } from 'common';
 import { Container, interfaces } from 'inversify';
 import { ContextAwareLogger } from 'logger';
-import { DefaultAzureCredential } from '@azure/identity';
 import { SecretClient } from '@azure/keyvault-secrets';
 import { StorageContainerSASUrlProvider } from './azure-blob/storage-container-sas-url-provider';
 import { CosmosClientWrapper } from './azure-cosmos/cosmos-client-wrapper';
@@ -85,9 +84,10 @@ async function getStorageAccountName(context: interfaces.Context): Promise<strin
 function setupBlobServiceClientProvider(container: interfaces.Container): void {
     IoC.setupSingletonProvider<BlobServiceClient>(iocTypeNames.BlobServiceClientProvider, container, async (context) => {
         const accountName = await getStorageAccountName(context);
-        const defaultAzureCredential = new DefaultAzureCredential();
+        const credentialsProvider = container.get(CredentialsProvider);
+        const azureCredential = credentialsProvider.getDefaultTokenCredential();
 
-        return new BlobServiceClient(`https://${accountName}.blob.core.windows.net`, defaultAzureCredential);
+        return new BlobServiceClient(`https://${accountName}.blob.core.windows.net`, azureCredential);
     });
 }
 
@@ -104,7 +104,8 @@ function setupAuthenticationMethod(container: interfaces.Container): void {
 
 function setupSingletonAzureKeyVaultClientProvider(container: interfaces.Container): void {
     IoC.setupSingletonProvider<SecretClient>(iocTypeNames.AzureKeyVaultClientProvider, container, async (context) => {
-        const credentials = new DefaultAzureCredential();
+        const credentialsProvider = container.get(CredentialsProvider);
+        const credentials = credentialsProvider.getDefaultTokenCredential();
 
         return new SecretClient(process.env.KEY_VAULT_URL, credentials);
     });
@@ -113,7 +114,8 @@ function setupSingletonAzureKeyVaultClientProvider(container: interfaces.Contain
 function setupSingletonQueueServiceClientProvider(container: interfaces.Container): void {
     IoC.setupSingletonProvider<QueueServiceClient>(iocTypeNames.QueueServiceClientProvider, container, async (context) => {
         const accountName = await getStorageAccountName(context);
-        const credential = new DefaultAzureCredential();
+        const credentialsProvider = container.get(CredentialsProvider);
+        const credential = credentialsProvider.getDefaultTokenCredential();
 
         return new QueueServiceClient(`https://${accountName}.queue.core.windows.net`, credential);
     });
@@ -130,9 +132,10 @@ function setupSingletonCosmosClientProvider(
         } else {
             const secretProvider = context.container.get(SecretProvider);
             cosmosDbUrl = await secretProvider.getSecret(secretNames.cosmosDbUrl);
-            const defaultAzureCredential = new DefaultAzureCredential();
+            const credentialsProvider = container.get(CredentialsProvider);
+            const credentials = credentialsProvider.getDefaultTokenCredential();
 
-            return cosmosClientFactory({ endpoint: cosmosDbUrl, aadCredentials: defaultAzureCredential });
+            return cosmosClientFactory({ endpoint: cosmosDbUrl, aadCredentials: credentials });
         }
     });
 }

--- a/packages/azure-services/src/register-azure-services-to-container.ts
+++ b/packages/azure-services/src/register-azure-services-to-container.ts
@@ -125,18 +125,14 @@ function setupSingletonCosmosClientProvider(
 ): void {
     IoC.setupSingletonProvider<CosmosClient>(iocTypeNames.CosmosClientProvider, container, async (context) => {
         let cosmosDbUrl: string;
-        let cosmosDbArmUrl: string;
         if (process.env.COSMOS_DB_URL !== undefined && process.env.COSMOS_DB_KEY !== undefined) {
             return cosmosClientFactory({ endpoint: process.env.COSMOS_DB_URL, key: process.env.COSMOS_DB_KEY });
         } else {
             const secretProvider = context.container.get(SecretProvider);
             cosmosDbUrl = await secretProvider.getSecret(secretNames.cosmosDbUrl);
-            cosmosDbArmUrl = await secretProvider.getSecret(secretNames.cosmosDbArmUrl);
+            const defaultAzureCredential = new DefaultAzureCredential();
 
-            const cosmosKeyProvider = context.container.get(CosmosKeyProvider);
-            const cosmosDbKey = await cosmosKeyProvider.getCosmosKey(cosmosDbArmUrl);
-
-            return cosmosClientFactory({ endpoint: cosmosDbUrl, key: cosmosDbKey });
+            return cosmosClientFactory({ endpoint: cosmosDbUrl, aadCredentials: defaultAzureCredential });
         }
     });
 }

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -49,6 +49,23 @@ grantAccessToAppGateway() {
     az keyvault set-policy --name "${keyVault}" --object-id "${identityId}" --secret-permissions get 1>/dev/null
 }
 
+grantAccessToCosmosDB() {
+    vnet=$(az network vnet list --resource-group ${nodeResourceGroup} --query "[].name" -o tsv)
+    nodeSubnetName="aks-subnet"
+    nodeSubnetId=$(az network vnet subnet list --resource-group ${nodeResourceGroup} --vnet-name ${vnet} --query "[?name=='${nodeSubnetName}'].id" -o tsv)
+    echo "Granting CosmosDB access to subnet ${nodeSubnetName} in vnet ${vnet}"
+
+    az network vnet subnet update \
+        --name ${nodeSubnetName} \
+        --resource-group ${nodeResourceGroup} \
+        --vnet-name ${vnet} \
+        --service-endpoints Microsoft.AzureCosmosDB 1>/dev/null
+    az cosmosdb network-rule add --name ${cosmosDbAccount} \
+        --resource-group ${resourceGroupName} \
+        --virtual-network ${vnet} \
+        --subnet "${nodeSubnetId}" 1>/dev/null
+}
+
 # Read script arguments
 while getopts ":r:c:l:d:" option; do
     case ${option} in
@@ -90,5 +107,6 @@ echo ""
 waitForAppGatewayUpdate
 grantAccessToCluster
 grantAccessToAppGateway
+grantAccessToCosmosDB
 
 echo "Azure Kubernetes Service successfully created."

--- a/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
+++ b/packages/resource-deployment/scripts/push-secrets-to-key-vault.sh
@@ -64,10 +64,6 @@ getCosmosDbUrl() {
     fi
 }
 
-getCosmosDbArmUrl() {
-    cosmosDbArmUrl="https://management.azure.com/subscriptions/${subscription}/resourceGroups/${resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount}"
-}
-
 getStorageAccessKey() {
     storageAccountKey=$(az storage account keys list --account-name "${storageAccount}" --query "[0].value" -o tsv)
 
@@ -112,9 +108,6 @@ pushSecretsToKeyVault() (
 
     getCosmosDbUrl
     pushSecretToKeyVault "cosmosDbUrl" "${cosmosDbUrl}"
-
-    getCosmosDbArmUrl
-    pushSecretToKeyVault "cosmosDbArmUrl" "${cosmosDbArmUrl}"
 
     getStorageAccessKey
     pushSecretToKeyVault "storageAccountName" "${storageAccount}"

--- a/packages/resource-deployment/templates/cosmos-db.template.json
+++ b/packages/resource-deployment/templates/cosmos-db.template.json
@@ -21,13 +21,14 @@
         {
             "name": "[parameters('name')]",
             "type": "Microsoft.DocumentDB/databaseAccounts",
-            "apiVersion": "2021-01-15",
+            "apiVersion": "2021-04-15",
             "location": "[parameters('location')]",
             "tags": {
                 "defaultExperience": "Core (SQL)"
             },
             "kind": "GlobalDocumentDB",
             "properties": {
+                "isVirtualNetworkFilterEnabled": true,
                 "consistencyPolicy": {
                     "defaultConsistencyLevel": "Session",
                     "maxIntervalInSeconds": 5,


### PR DESCRIPTION
#### Details

- Use AAD to authenticate to cosmosDB instead of primary key (currently in private preview)
- Restrict cosmosDB access to the subnet containing the kubernetes nodes

##### Motivation

These changes are required for security compliance

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
