### PR TITLE
Enable encryption at host for AKS cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ test-results/
 **/.secrets
 **/.env
 **/*.generated.template.json
+**/*.generated.json
 **/*.DS_Store
 **/bin
 **/obj

--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -52,7 +52,8 @@
         ],
         "eslint.enable": true,
         "editor.codeActionsOnSave": {
-            "source.fixAll.eslint": true
+            "source.fixAll.eslint": true,
+            "source.fixAll.shellcheck": true
         },
         "shellformat.effectLanguages": [
             "shellscript"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build": "npx lerna run build --stream",
         "test": "npx jest",
         "publish-code-coverage": "npx codecov",
-        "lint:check": "npx lerna run lint --stream && npx shellcheck -x **/*.sh",
+        "lint:check": "npx lerna run lint --stream && npx shellcheck --source-path=./packages/resource-deployment/scripts/ ./packages/resource-deployment/scripts/*.sh",
         "lint:fix": "npx lerna run lint:fix --stream",
         "precheckin": "npm-run-all --serial format:check lint:check copyright:check cbuild test",
         "format:fix": "npx prettier --write \"**/*\"",

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -66,6 +66,29 @@ grantAccessToCosmosDB() {
         --subnet "${nodeSubnetId}" 1>/dev/null
 }
 
+registerEncryptionAtHost() {
+    local end=$((SECONDS + 1800))
+
+    echo "Registering the EncryptionAtHost feature flags on subscription"
+    az feature register --namespace "Microsoft.Compute" --name "EncryptionAtHost" 1>/dev/null
+
+    printf " - Registering .."
+    while [ "${SECONDS}" -le "${end}" ]; do
+        state=$(az feature list -o table --query "[?contains(name, 'Microsoft.Compute/EncryptionAtHost')].{State:properties.state}" -o tsv)
+        if [[ ${state} == "Registered" ]]; then
+            break
+        else
+            printf "."
+        fi
+
+        sleep 20
+    done
+    echo " Registered"
+
+    # Refresh the registration of the Microsoft.Compute resource providers
+    az provider register --namespace Microsoft.Compute 1>/dev/null
+}
+
 # Read script arguments
 while getopts ":r:c:l:d:" option; do
     case ${option} in
@@ -89,11 +112,15 @@ fi
 # Get the default subscription
 subscription=$(az account show --query "id" -o tsv)
 
+# Enable the EncryptionAtHost feature flags on subscription
+registerEncryptionAtHost
+
 # Deploy Azure Kubernetes Service
 echo "Deploying Azure Kubernetes Service in resource group ${resourceGroupName}"
 az aks create --resource-group "${resourceGroupName}" --name "${kubernetesService}" --location "${location}" \
     --no-ssh-key \
     --enable-managed-identity \
+    --enable-encryption-at-host \
     --network-plugin azure \
     --appgw-name "${appGateway}" \
     --appgw-subnet-cidr "10.2.0.0/16" \

--- a/packages/resource-deployment/scripts/create-public-network.sh
+++ b/packages/resource-deployment/scripts/create-public-network.sh
@@ -32,7 +32,7 @@ setPublicDNSPrefix() {
 }
 
 createCertificatePolicyFile() {
-    certificatePolicyFile="${0%/*}/certificate-policy.${frontEndPublicCertificate}.json"
+    certificatePolicyFile="${0%/*}/certificate-policy.${frontEndPublicCertificate}.generated.json"
     certificatePolicyTemplateFile="${0%/*}/../templates/certificate-policy.template.json"
 
     sed -e "s@<SUBJECT>@CN=${fqdn}@" -e "s@<DNSNAME>@${fqdn}@" "${certificatePolicyTemplateFile}" >"${certificatePolicyFile}"


### PR DESCRIPTION
#### Details

Enable encryption at host for AKS cluster

##### Motivation

Thread review requirements
Enable shellcheck for bash scripts at build time

##### Context

[Host-based encryption on Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/enable-host-encryption)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
