### PR TITLE
AccessibilityPageScan

### DIFF
--- a/packages/api-contracts/src/test-data/sample-page-scan-data.ts
+++ b/packages/api-contracts/src/test-data/sample-page-scan-data.ts
@@ -11,7 +11,9 @@ export const pendingPageScan: PageScan = {
         url: 'https://pending-page.com',
     },
     priority: 1,
-    scanStatus: 'pending',
+    run: {
+        state: 'pending',
+    },
 };
 
 export const passedPageScan: PageScan = {
@@ -22,14 +24,14 @@ export const passedPageScan: PageScan = {
         url: 'https://passed-page.com',
     },
     priority: 1,
-    scanStatus: 'pass',
-    completedTimestamp: 123456,
-    results: [
-        {
-            blobId: 'results blob id',
-            resultType: 'result type',
-        },
-    ],
+    run: {
+        state: 'completed',
+        timestamp: 123456,
+        retryCount: 1,
+    },
+    result: {
+        state: 'pass',
+    },
     reports: [
         {
             reportId: 'passed page html report id',

--- a/packages/api-contracts/src/types/page-scan.ts
+++ b/packages/api-contracts/src/types/page-scan.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BlobResultData, ReportData, ScanStatus } from 'storage-documents';
+import { ReportData, ScanResult, ScanRun } from 'storage-documents';
 import { Page } from './page';
 
 export interface PageScan {
@@ -9,9 +9,7 @@ export interface PageScan {
     websiteScanId?: string;
     page: Page;
     priority: number;
-    scanStatus: ScanStatus;
-    completedTimestamp?: number;
-    results?: BlobResultData[];
     reports?: ReportData[];
-    scanError?: string;
+    result?: ScanResult;
+    run: ScanRun;
 }

--- a/packages/service-library/src/data-providers/page-scan-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.spec.ts
@@ -26,8 +26,9 @@ describe(PageScanProvider, () => {
         partitionKey: partitionKey,
         itemType: itemTypes.pageScan,
         priority: priority,
-        scanStatus: 'pending',
-        retryCount: 0,
+        run: {
+            state: 'pending',
+        },
     } as PageScan;
     let cosmosContainerClientMock: IMock<CosmosContainerClient>;
     let guidGeneratorMock: IMock<GuidGenerator>;
@@ -84,7 +85,12 @@ describe(PageScanProvider, () => {
 
         it('throws if no id', () => {
             const pageScanUpdate: Partial<PageScan> = {
-                scanStatus: 'pass',
+                result: {
+                    state: 'pass',
+                },
+                run: {
+                    state: 'completed',
+                },
             };
 
             expect(testSubject.updatePageScan(pageScanUpdate)).rejects.toThrow();
@@ -93,7 +99,12 @@ describe(PageScanProvider, () => {
         it('Errors if no partition key is provided and the fields needed to compute it are missing', () => {
             const pageScanUpdate: Partial<PageScan> = {
                 id: pageScanId,
-                scanStatus: 'pass',
+                result: {
+                    state: 'pass',
+                },
+                run: {
+                    state: 'completed',
+                },
             };
 
             expect(testSubject.updatePageScan(pageScanUpdate)).rejects.toThrow();
@@ -101,7 +112,12 @@ describe(PageScanProvider, () => {
 
         it('updates doc with normalized properties when pageId is present', async () => {
             const updatedScanData: Partial<PageScan> = {
-                scanStatus: 'pass',
+                result: {
+                    state: 'pass',
+                },
+                run: {
+                    state: 'completed',
+                },
                 id: pageScanId,
                 pageId: pageId,
             };
@@ -123,7 +139,12 @@ describe(PageScanProvider, () => {
 
         it('updates doc with normalized properties when websiteScanId is present', async () => {
             const updatedScanData: Partial<PageScan> = {
-                scanStatus: 'pass',
+                result: {
+                    state: 'pass',
+                },
+                run: {
+                    state: 'completed',
+                },
                 id: pageScanId,
                 websiteScanId: websiteScanId,
             };
@@ -145,7 +166,12 @@ describe(PageScanProvider, () => {
 
         it('uses partitionKey if one is provided', async () => {
             const updatedScanData: Partial<PageScan> = {
-                scanStatus: 'pass',
+                result: {
+                    state: 'pass',
+                },
+                run: {
+                    state: 'completed',
+                },
                 id: pageScanId,
                 partitionKey: 'provided partition key',
             };
@@ -262,7 +288,7 @@ describe(PageScanProvider, () => {
 
         it('queries db with expected query when completed=true', async () => {
             const expectedFilterConditions =
-                'c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId and c.pageId = @pageId and c.scanStatus != "pending"';
+                'c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId and c.pageId = @pageId and (c.run.state == "completed" or c.run.state == "failed")';
             const expectedQuery = getExpectedQueryWithConditions(expectedFilterConditions);
             const response = {
                 statusCode: 200,

--- a/packages/service-library/src/data-providers/page-scan-provider.ts
+++ b/packages/service-library/src/data-providers/page-scan-provider.ts
@@ -23,8 +23,9 @@ export class PageScanProvider {
             pageId: pageId,
             websiteScanId: websiteScanId,
             priority: priority,
-            scanStatus: 'pending',
-            retryCount: 0,
+            run: {
+                state: 'pending',
+            },
         };
         const pageScanDocument = this.normalizeDbDocument(pageScanData) as PageScan;
         await this.cosmosContainerClient.writeDocument(this.normalizeDbDocument(pageScanDocument));
@@ -75,7 +76,7 @@ export class PageScanProvider {
         let filterConditions =
             'c.partitionKey = @partitionKey and c.itemType = @itemType and c.websiteScanId = @websiteScanId and c.pageId = @pageId';
         if (completed) {
-            filterConditions = `${filterConditions} and c.scanStatus != "pending"`;
+            filterConditions = `${filterConditions} and (c.run.state == "completed" or c.run.state == "failed")`;
         }
         const query = {
             query: `SELECT TOP 1 * FROM c WHERE ${filterConditions} ORDER BY c._ts DESC`,

--- a/packages/storage-documents/src/index.ts
+++ b/packages/storage-documents/src/index.ts
@@ -3,11 +3,15 @@
 
 export { BlobResultData } from './blob-result-data';
 export { itemTypes, ItemType } from './item-type';
-export { PageScan } from './page-scan';
+export * from './page-scan';
 export { Page } from './page';
 export { PartitionKey } from './partition-key';
 export { ReportData, PageReportFormat } from './report-data';
 export { WebsiteScan } from './website-scan';
 export { Website } from './website';
-export { ScanType, ScanStatus } from './scan-types';
+export * from './scan-types';
 export { DocumentDataOnly, StorageDocument } from './storage-document';
+export * from './scan-result-types/scan-result';
+export { AccessibilityScanResult } from './scan-result-types/accessibility-scan-result';
+export * from './scan-run-types/scan-run';
+export * from './scan-run-types/accessibility-scan-run';

--- a/packages/storage-documents/src/page-scan.ts
+++ b/packages/storage-documents/src/page-scan.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import { ReportData } from './report-data';
-import { ScanStatus } from './scan-types';
 import { StorageDocument } from './storage-document';
 import { ItemTypes } from './item-type';
-import { BlobResultData } from './blob-result-data';
+import { ScanResult } from './scan-result-types/scan-result';
+import { ScanRun } from './scan-run-types/scan-run';
+import { AccessibilityScanResult } from './scan-result-types/accessibility-scan-result';
+import { AccessibilityScanRun } from './scan-run-types/accessibility-scan-run';
 
 /*
  * Represents a scan/crawl of a single URL for one scan type.
@@ -16,10 +18,12 @@ export interface PageScan extends StorageDocument {
     websiteScanId: string; // maps to a WebsiteScan document
     pageId: string; // maps to a Page document
     priority: number;
-    scanStatus: ScanStatus;
-    completedTimestamp?: number;
-    results?: BlobResultData[];
     reports?: ReportData[];
-    retryCount: number;
-    scanError?: string;
+    result?: ScanResult;
+    run: ScanRun;
+}
+
+export interface AccessibilityPageScan extends PageScan {
+    result: AccessibilityScanResult;
+    run: AccessibilityScanRun;
 }

--- a/packages/storage-documents/src/scan-result-types/accessibility-scan-result.ts
+++ b/packages/storage-documents/src/scan-result-types/accessibility-scan-result.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BlobResultData } from '..';
+import { ScanResult } from './scan-result';
+
+export interface AccessibilityScanResult extends ScanResult {
+    issueCount?: number;
+    axeResultBlob?: BlobResultData;
+}

--- a/packages/storage-documents/src/scan-result-types/scan-result.ts
+++ b/packages/storage-documents/src/scan-result-types/scan-result.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type ScanResultState = 'pass' | 'fail';
+
+export interface ScanResult {
+    state: ScanResultState;
+}

--- a/packages/storage-documents/src/scan-run-types/accessibility-scan-run.ts
+++ b/packages/storage-documents/src/scan-run-types/accessibility-scan-run.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ScanRun } from './scan-run';
+
+export declare type AccessibilityScanErrorTypes =
+    | 'UrlNavigationTimeout'
+    | 'SslError'
+    | 'ResourceLoadFailure'
+    | 'InvalidUrl'
+    | 'EmptyPage'
+    | 'HttpErrorCode'
+    | 'NavigationError'
+    | 'InvalidContentType'
+    | 'UrlNotResolved'
+    | 'ScanTimeout'
+    | 'InternalError';
+
+export interface AccessibilityScanError {
+    errorType: AccessibilityScanErrorTypes;
+    message: string;
+}
+
+export interface AccessibilityScanRun extends ScanRun {
+    error?: string | AccessibilityScanError;
+    pageTitle?: string;
+    scannedUrl?: string;
+    pageResponseCode?: number;
+}

--- a/packages/storage-documents/src/scan-run-types/scan-run.ts
+++ b/packages/storage-documents/src/scan-run-types/scan-run.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export type PageScanRunState = 'pending' | 'accepted' | 'queued' | 'running' | 'completed' | 'failed';
+
+export interface ScanRun {
+    timestamp?: number;
+    retryCount?: number;
+    state: PageScanRunState;
+}

--- a/packages/storage-web-api/src/converters/page-scan-document-response-converter.spec.ts
+++ b/packages/storage-web-api/src/converters/page-scan-document-response-converter.spec.ts
@@ -24,12 +24,15 @@ describe(createPageScanApiObject, () => {
     const pageScanDoc: StorageDocuments.PageScan = {
         id: 'page scan id',
         pageId: 'page id',
-        scanStatus: 'pending',
         websiteScanId: 'website scan id',
         priority: 0,
-        retryCount: 1,
-        completedTimestamp: 1234,
-        results: [{ blobId: 'blob id', resultType: 'test result type' }],
+        run: {
+            state: 'completed',
+            retryCount: 1,
+        },
+        result: {
+            state: 'pass',
+        },
         reports: [{ reportId: 'report id', format: 'html', href: 'href' }],
         itemType: StorageDocuments.itemTypes.pageScan,
         partitionKey: 'partition key',
@@ -46,9 +49,8 @@ describe(createPageScanApiObject, () => {
         const expectedResponse: ApiContracts.PageScan = {
             id: pageScanDoc.id,
             page: pageObject,
-            scanStatus: pageScanDoc.scanStatus,
-            completedTimestamp: pageScanDoc.completedTimestamp,
-            results: pageScanDoc.results,
+            run: pageScanDoc.run,
+            result: pageScanDoc.result,
             reports: pageScanDoc.reports,
             priority: 0,
         };

--- a/packages/storage-web-api/src/converters/page-scan-document-response-converter.ts
+++ b/packages/storage-web-api/src/converters/page-scan-document-response-converter.ts
@@ -16,10 +16,8 @@ export const createPageScanApiObject = (
         id: pageScanDocument.id,
         page: createPageObject(pageDocument),
         priority: pageScanDocument.priority,
-        scanStatus: pageScanDocument.scanStatus,
-        completedTimestamp: pageScanDocument.completedTimestamp,
-        results: pageScanDocument.results,
         reports: pageScanDocument.reports,
-        scanError: pageScanDocument.scanError,
+        result: pageScanDocument.result,
+        run: pageScanDocument.run,
     };
 };


### PR DESCRIPTION
#### Details

This extends the PageScan storage document to support data specific to accessibility scans, while still being extensible to other data types. The PageScan, ScanRun, and ScanResult interfaces contain common fields to be used in crawling and scan queueing. Page scan documents for specific scan types can override ScanRun and ScanResult and add their own fields (as with AccessibilityPageScan in this PR)

##### Motivation

This will allow web insights storage to support data specific to accessibility scans, while still being able to extend to other scan types.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
