### PR TITLE
chore: add manifest generator task to build yaml

### DIFF
--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -33,7 +33,7 @@ steps:
       displayName: Copy files to staging directory
 
     - task: ManifestGeneratorTask@0
-      displayName: 'Generation Task'
+      displayName: 'SBOM Generation Task'
       inputs:
           BuildDropPath: '$(Build.ArtifactStagingDirectory)'
 

--- a/azure-pipeline/build-artifacts-and-run-tests-job.yaml
+++ b/azure-pipeline/build-artifacts-and-run-tests-job.yaml
@@ -32,6 +32,11 @@ steps:
           TargetFolder: '$(Build.ArtifactStagingDirectory)'
       displayName: Copy files to staging directory
 
+    - task: ManifestGeneratorTask@0
+      displayName: 'Generation Task'
+      inputs:
+          BuildDropPath: '$(Build.ArtifactStagingDirectory)'
+
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
#### Details

Adds manifest generator to build pipeline. [Successful test run here.](https://dev.azure.com/web-insights-private/Web%20Insights%20(private)/_build/results?buildId=797&view=results0)

##### Motivation

To make sure our pipelines meet the [executive order requirements](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
