### PR TITLE
Update combined dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "jest": "^27.2.4",
         "jest-extended": "^0.11.5",
         "jest-html-reporter": "^3.4.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "lerna": "^4.0.0",
         "license-check-and-add": "^4.0.2",
         "npm-run-all": "^4.1.5",

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -25,7 +25,7 @@
         "@types/jest": "^27.0.2",
         "@types/node": "^12.20.28",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "ts-transformer-keys": "^0.4.3",

--- a/packages/api-contracts/package.json
+++ b/packages/api-contracts/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/Microsoft/web-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -37,7 +37,7 @@
         "ts-loader": "^9.2.6",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.56.1",
+        "webpack": "^5.57.1",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -27,7 +27,7 @@
         "@types/lodash": "^4.14.175",
         "@types/verror": "^1.10.4",
         "@types/yargs": "^17.0.3",
-        "fork-ts-checker-webpack-plugin": "^6.3.3",
+        "fork-ts-checker-webpack-plugin": "^6.3.4",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",
         "mockdate": "^3.0.5",

--- a/packages/azure-services/package.json
+++ b/packages/azure-services/package.json
@@ -29,7 +29,7 @@
         "@types/yargs": "^17.0.3",
         "fork-ts-checker-webpack-plugin": "^6.3.4",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "mockdate": "^3.0.5",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -29,7 +29,7 @@
         "@types/sha.js": "^2.4.0",
         "@types/wtfnode": "^0.7.0",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@types/convict": "^6.0.2",
         "@types/jest": "^27.0.2",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "@types/normalize-path": "^3.0.0",
         "@types/sha.js": "^2.4.0",
         "@types/wtfnode": "^0.7.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -24,7 +24,7 @@
         "@types/jest": "^27.0.2",
         "@types/node": "^12.20.28",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/Microsoft/web-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",
         "reflect-metadata": "^0.1.13",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -28,7 +28,7 @@
         "@types/node": "^12.20.28",
         "@types/verror": "^1.10.4",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -25,7 +25,7 @@
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.173",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "@types/verror": "^1.10.4",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -26,7 +26,7 @@
         "@types/node": "^12.20.28",
         "jest": "^27.2.1",
         "jest-extended": "^0.11.5",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.5",
         "typemoq": "^2.1.0",

--- a/packages/service-library/package.json
+++ b/packages/service-library/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/Microsoft/web-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "jest": "^27.2.1",
         "jest-extended": "^0.11.5",
         "jest-junit": "^12.3.0",

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -23,7 +23,7 @@
     "homepage": "https://github.com/Microsoft/web-insights-service#readme",
     "devDependencies": {
         "@types/jest": "^27.0.2",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",
         "rimraf": "^3.0.2",

--- a/packages/storage-documents/package.json
+++ b/packages/storage-documents/package.json
@@ -25,7 +25,7 @@
         "@types/jest": "^27.0.2",
         "@types/node": "^12.20.28",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "rimraf": "^3.0.2",
         "ts-transformer-keys": "^0.4.3",
         "ts-jest": "^27.0.5",

--- a/packages/storage-web-api/package.json
+++ b/packages/storage-web-api/package.json
@@ -41,7 +41,7 @@
         "ts-loader": "^9.2.6",
         "typemoq": "^2.1.0",
         "typescript": "^4.4.3",
-        "webpack": "^5.56.1",
+        "webpack": "^5.57.1",
         "webpack-cli": "^4.8.0"
     },
     "dependencies": {

--- a/packages/storage-web-api/package.json
+++ b/packages/storage-web-api/package.json
@@ -31,7 +31,7 @@
         "@types/verror": "^1.10.4",
         "@types/yargs": "^17.0.3",
         "copy-webpack-plugin": "^9.0.0",
-        "fork-ts-checker-webpack-plugin": "^6.3.3",
+        "fork-ts-checker-webpack-plugin": "^6.3.4",
         "jest": "^27.2.1",
         "jest-junit": "^12.3.0",
         "node-loader": "^2.0.0",

--- a/packages/storage-web-api/package.json
+++ b/packages/storage-web-api/package.json
@@ -27,7 +27,7 @@
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^27.0.2",
         "@types/lodash": "^4.14.173",
-        "@types/node": "^12.20.27",
+        "@types/node": "^12.20.28",
         "@types/verror": "^1.10.4",
         "@types/yargs": "^17.0.3",
         "copy-webpack-plugin": "^9.0.0",

--- a/packages/storage-web-api/package.json
+++ b/packages/storage-web-api/package.json
@@ -33,7 +33,7 @@
         "copy-webpack-plugin": "^9.0.0",
         "fork-ts-checker-webpack-plugin": "^6.3.4",
         "jest": "^27.2.1",
-        "jest-junit": "^12.3.0",
+        "jest-junit": "^13.0.0",
         "node-loader": "^2.0.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12011,10 +12011,10 @@ webpack-sources@^3.2.0:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.0.tgz#b16973bcf844ebcdb3afde32eda1c04d0b90f89d"
   integrity sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==
 
-webpack@^5.56.1:
-  version "5.56.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.56.1.tgz#e39d1d1f1acdb6f07e346f74b7dcfe323da4ded9"
-  integrity sha512-MRbTPooHJuSAfbx7Lh/qEMRUe/d0p4cRj2GPo/fq+4JUeR/+Q1EfLvS1lexslbMcJZyPXxxz/k/NzVepkA5upA==
+webpack@^5.57.1:
+  version "5.57.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.57.1.tgz#ead5ace2c17ecef2ae8126f143bfeaa7f55eab44"
+  integrity sha512-kHszukYjTPVfCOEyrUthA3jqJwduY/P3eO8I0gMNOZGIQWKAwZftxmp5hq6paophvwo9NoUrcZOecs9ulOyyTg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3024,10 +3024,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.1.tgz#9b60797dee1895383a725f828a869c86c6caa5c2"
   integrity sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==
 
-"@types/node@^12.12.7", "@types/node@^12.20.27":
-  version "12.20.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.27.tgz#4141fcad57c332a120591de883e26fe4bb14aaea"
-  integrity sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg==
+"@types/node@^12.12.7", "@types/node@^12.20.28":
+  version "12.20.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.28.tgz#4b20048c6052b5f51a8d5e0d2acbf63d5a17e1e2"
+  integrity sha512-cBw8gzxUPYX+/5lugXIPksioBSbE42k0fZ39p+4yRzfYjN6++eq9kAPdlY9qm+MXyfbk9EmvCYAYRn380sF46w==
 
 "@types/node@^8.0.47":
   version "8.10.66"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7466,13 +7466,13 @@ jest-jasmine2@^27.2.4:
     pretty-format "^27.2.4"
     throat "^6.0.1"
 
-jest-junit@^12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.3.0.tgz#ee41a74e439eecdc8965f163f83035cce5998d6d"
-  integrity sha512-+NmE5ogsEjFppEl90GChrk7xgz8xzvF0f+ZT5AnhW6suJC93gvQtmQjfyjDnE0Z2nXJqEkxF0WXlvjG/J+wn/g==
+jest-junit@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.0.0.tgz#479be347457aad98ae8a5983a23d7c3ec526c9a3"
+  integrity sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==
   dependencies:
     mkdirp "^1.0.4"
-    strip-ansi "^5.2.0"
+    strip-ansi "^6.0.1"
     uuid "^8.3.2"
     xml "^1.0.1"
 
@@ -11098,7 +11098,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@6.0.0, strip-ansi@^6.0.0:
+strip-ansi@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
@@ -11125,6 +11125,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2967,12 +2967,7 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
-  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
-
-"@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
@@ -5877,10 +5872,10 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-fork-ts-checker-webpack-plugin@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.3.3.tgz#73a9d8e1dc5821fa19a3daedc8be7568b095c8ab"
-  integrity sha512-S3uMSg8IsIvs0H6VAfojtbf6RcnEXxEpDMT2Q41M2l0m20JO8eA1t4cCJybvrasC8SvvPEtK4B8ztxxfLljhNg==
+fork-ts-checker-webpack-plugin@^6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.3.4.tgz#9af17de0a36caf6f1b4e1d2d081cf586f0a12b14"
+  integrity sha512-z0dns2NXH9NHH0wpW6iuUmyXYRN9BI2Lqnv+RCdL+9GXSW6tKUqYnwf+h3ZaucJsbsrdobdxuOELGgm1xVZITA==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"


### PR DESCRIPTION
This PR was created by the Combine PRs action by combining the following PRs:

* #303 chore(deps-dev): bump fork-ts-checker-webpack-plugin from 6.3.3 to 6.3.4
* #302 chore(deps-dev): bump @types/node from 12.20.27 to 12.20.28
* #301 chore(deps-dev): bump jest-junit from 12.3.0 to 13.0.0
* #300 chore(deps-dev): bump webpack from 5.56.1 to 5.57.1
