### PR TITLE
Use ubuntu 20.04 for build pipeline

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -5,16 +5,8 @@ name: $(Build.SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 jobs:
     - job: 'BuildArtifactsAndRunSomeTests'
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-20.04'
           demands: npm
       steps:
           - template: ./azure-pipeline/build-artifacts-and-run-tests-job.yaml
             parameters: { totalTestSlices: 1, testSlicesToRun: '[0]' }
-
-    # - job: 'RunRemainingTests'
-    #   pool:
-    #       vmImage: 'ubuntu-16.04'
-    #       demands: npm
-    #   steps:
-    #       - template: ./azure-pipeline/run-tests-job.yaml
-    #         parameters: { totalTestSlices: 1, testSlicesToRun: '[0]' }


### PR DESCRIPTION
#### Details

Change build agent to use ubuntu-20.04 instead of ubuntu-16.04

##### Motivation

Ubuntu 16 is no longer supported for our build pipelines ([failing build example](https://dev.azure.com/web-insights-private/Web%20Insights%20(private)/_build/results?buildId=881&view=results)).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] Validated in an Azure resource group
