### PR TITLE
Add authentication to storage API client

### DIFF
--- a/packages/storage-api-client/package.json
+++ b/packages/storage-api-client/package.json
@@ -34,6 +34,8 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
+        "@azure/msal-common": "^5.2.0",
+        "@azure/msal-node": "^1.4.0",
         "api-contracts": "1.0.0",
         "common": "1.0.0",
         "got": "^11.8.1",

--- a/packages/storage-api-client/package.json
+++ b/packages/storage-api-client/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@azure/msal-common": "^5.2.0",
-        "@azure/msal-node": "^1.4.0",
+        "@azure/msal-node": "^1.3.2",
         "api-contracts": "1.0.0",
         "common": "1.0.0",
         "got": "^11.8.1",

--- a/packages/storage-api-client/src/web-insights-api-credential.spec.ts
+++ b/packages/storage-api-client/src/web-insights-api-credential.spec.ts
@@ -65,7 +65,7 @@ describe(WebInsightsAPICredential, () => {
         setupRetryHelperMock(false);
         loggerMock.setup((l) => l.logError(It.isAny(), It.isAny())).verifiable();
 
-        expect(testSubject.getAuthHeaders()).rejects.toThrow(error);
+        expect(testSubject.getToken()).rejects.toThrow(error);
     });
 
     it('Gets token with expected options', async () => {
@@ -85,9 +85,9 @@ describe(WebInsightsAPICredential, () => {
             .verifiable();
         setupRetryHelperMock(true);
 
-        const headers = await testSubject.getAuthHeaders();
+        const tokenResult = await testSubject.getToken();
 
-        expect(headers.authorization).toEqual(`Bearer ${accessToken}`);
+        expect(tokenResult).toEqual(authResult);
     });
 
     function setupRetryHelperMock(shouldSucceed: boolean): void {

--- a/packages/storage-api-client/src/web-insights-api-credential.spec.ts
+++ b/packages/storage-api-client/src/web-insights-api-credential.spec.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import { RetryHelper } from 'common';
+import { IMock, It, Mock } from 'typemoq';
+import { AuthenticationResult } from '@azure/msal-common';
+import { ClientCredentialRequest, ConfidentialClientApplication, Configuration } from '@azure/msal-node';
+import { GlobalLogger } from 'logger';
+import { ConfidentialClientApplicationFactory, WebInsightsAPICredential } from './web-insights-api-credential';
+
+describe(WebInsightsAPICredential, () => {
+    const clientId = 'client id';
+    const clientSecret = 'client secret';
+    const resourceClientId = 'resource id';
+    const authUrl = 'auth url';
+    const maxTokenAttempts = 3;
+    const msecBetweenRetries = 10;
+    const expectedClientAppOptions: Configuration = {
+        auth: {
+            clientId: clientId,
+            clientSecret: clientSecret,
+            authority: authUrl,
+        },
+    };
+    const error = new Error('Test error');
+
+    let loggerMock: IMock<GlobalLogger>;
+    let retryHelperMock: IMock<RetryHelper<AuthenticationResult>>;
+    let clientAppMock: IMock<ConfidentialClientApplication>;
+    let clientAppFactoryMock: IMock<ConfidentialClientApplicationFactory>;
+
+    let testSubject: WebInsightsAPICredential;
+
+    beforeEach(() => {
+        loggerMock = Mock.ofType<GlobalLogger>();
+        retryHelperMock = Mock.ofType<RetryHelper<AuthenticationResult>>();
+        clientAppMock = Mock.ofType<ConfidentialClientApplication>();
+        clientAppFactoryMock = Mock.ofType<ConfidentialClientApplicationFactory>();
+
+        clientAppFactoryMock.setup((f) => f(expectedClientAppOptions)).returns(() => clientAppMock.object);
+
+        testSubject = new WebInsightsAPICredential(
+            clientId,
+            clientSecret,
+            authUrl,
+            resourceClientId,
+            loggerMock.object,
+            maxTokenAttempts,
+            msecBetweenRetries,
+            retryHelperMock.object,
+            clientAppFactoryMock.object,
+        );
+    });
+
+    afterEach(() => {
+        clientAppMock.verifyAll();
+        loggerMock.verifyAll();
+        retryHelperMock.verifyAll();
+    });
+
+    it('Logs and throws error if token request throws', () => {
+        clientAppMock.setup((c) => c.acquireTokenByClientCredential(It.isAny())).throws(error);
+        setupRetryHelperMock(false);
+        loggerMock.setup((l) => l.logError(It.isAny(), It.isAny())).verifiable();
+
+        expect(testSubject.getAuthHeaders()).rejects.toThrow(error);
+    });
+
+    it('Gets token with expected options', async () => {
+        const expectedResourceUri = `api://${resourceClientId}/.default`;
+        const expectedClientRequest: ClientCredentialRequest = {
+            scopes: [expectedResourceUri],
+        };
+        const accessToken = 'access token';
+        const authResult = {
+            tokenType: 'Bearer',
+            accessToken: accessToken,
+        } as AuthenticationResult;
+
+        clientAppMock
+            .setup((c) => c.acquireTokenByClientCredential(expectedClientRequest))
+            .returns(async () => authResult)
+            .verifiable();
+        setupRetryHelperMock(true);
+
+        const headers = await testSubject.getAuthHeaders();
+
+        expect(headers.authorization).toEqual(`Bearer ${accessToken}`);
+    });
+
+    function setupRetryHelperMock(shouldSucceed: boolean): void {
+        retryHelperMock
+            .setup((r) => r.executeWithRetries(It.isAny(), It.isAny(), maxTokenAttempts, msecBetweenRetries))
+            .returns(
+                async (action: () => Promise<AuthenticationResult>, errorHandler: (err: Error) => Promise<void>, maxAttempts: number) => {
+                    if (shouldSucceed) {
+                        return action();
+                    } else {
+                        await errorHandler(error);
+                        throw error;
+                    }
+                },
+            )
+            .verifiable();
+    }
+});

--- a/packages/storage-api-client/src/web-insights-api-credential.ts
+++ b/packages/storage-api-client/src/web-insights-api-credential.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AuthenticationResult } from '@azure/msal-common';
+import { ConfidentialClientApplication, Configuration } from '@azure/msal-node';
+import { RetryHelper, System } from 'common';
+import { Headers } from 'got';
+import { Logger } from 'logger';
+
+export type ConfidentialClientApplicationFactory = (config: Configuration) => ConfidentialClientApplication;
+const defaultClientApplicationFactory = (config: Configuration) => new ConfidentialClientApplication(config);
+
+export class WebInsightsAPICredential {
+    private readonly app: ConfidentialClientApplication;
+
+    private readonly tokenScope: string;
+
+    constructor(
+        clientId: string,
+        clientSecret: string,
+        authorityUrl: string,
+        resourceClientId: string,
+        private readonly logger: Logger,
+        private readonly maxTokenAttempts: number = 5,
+        private readonly msecBetweenRetries: number = 1000,
+        private readonly retryHelper: RetryHelper<AuthenticationResult> = new RetryHelper(),
+        clientApplicationFactory: ConfidentialClientApplicationFactory = defaultClientApplicationFactory,
+    ) {
+        this.tokenScope = `api://${resourceClientId}/.default`;
+        const config: Configuration = {
+            auth: {
+                clientId: clientId,
+                clientSecret: clientSecret,
+                authority: authorityUrl,
+            },
+        };
+        this.app = clientApplicationFactory(config);
+    }
+
+    public async getAuthHeaders(): Promise<Headers> {
+        const accessToken = await this.getToken();
+
+        return {
+            authorization: `${accessToken.tokenType} ${accessToken.accessToken}`,
+        };
+    }
+
+    private async getToken(): Promise<AuthenticationResult> {
+        return this.retryHelper.executeWithRetries(
+            () =>
+                this.app.acquireTokenByClientCredential({
+                    scopes: [this.tokenScope],
+                }),
+            async (error) => this.logger.logError(`Error while acquiring Azure AD client token. ${System.serializeError(error)}`),
+            this.maxTokenAttempts,
+            this.msecBetweenRetries,
+        );
+    }
+}

--- a/packages/storage-api-client/src/web-insights-api-credential.ts
+++ b/packages/storage-api-client/src/web-insights-api-credential.ts
@@ -4,7 +4,6 @@
 import { AuthenticationResult } from '@azure/msal-common';
 import { ConfidentialClientApplication, Configuration } from '@azure/msal-node';
 import { RetryHelper, System } from 'common';
-import { Headers } from 'got';
 import { Logger } from 'logger';
 
 export type ConfidentialClientApplicationFactory = (config: Configuration) => ConfidentialClientApplication;
@@ -37,15 +36,7 @@ export class WebInsightsAPICredential {
         this.app = clientApplicationFactory(config);
     }
 
-    public async getAuthHeaders(): Promise<Headers> {
-        const accessToken = await this.getToken();
-
-        return {
-            authorization: `${accessToken.tokenType} ${accessToken.accessToken}`,
-        };
-    }
-
-    private async getToken(): Promise<AuthenticationResult> {
+    public async getToken(): Promise<AuthenticationResult> {
         return this.retryHelper.executeWithRetries(
             () =>
                 this.app.acquireTokenByClientCredential({

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,7 +263,7 @@
   dependencies:
     debug "^4.1.1"
 
-"@azure/msal-node@^1.3.0", "@azure/msal-node@^1.3.2":
+"@azure/msal-node@^1.3.0":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.3.2.tgz#17665397c04b9cad57b42eb6e21d5d6f35d9b83a"
   integrity sha512-aKU2lVRKhZa1IJ/Za/Ir6qlythQ3FHz0g0px3SbM4iC1otyr3ANS4mIn/6fmkpZDIHc8eAgJh2KMep1Yn2zpig==
@@ -273,7 +273,7 @@
     jsonwebtoken "^8.5.1"
     uuid "^8.3.0"
 
-"@azure/msal-node@^1.4.0":
+"@azure/msal-node@^1.3.2":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.4.0.tgz#660685804fbdc533b10cc699f16323e27ec582c6"
   integrity sha512-Ek6hqOFUi5QEAxZ55awM8y1N+9SzS9Qh8ijF4RDLtFuHzqP7xXmMnVC1lae45FlH55DUOo7dg/smuDJnb4kw6g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,12 +256,29 @@
   dependencies:
     debug "^4.1.1"
 
+"@azure/msal-common@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-5.2.0.tgz#49440e04f4d0961fc5a1a1718fbe5e4eae2db5db"
+  integrity sha512-oVc4soy5MEZOp9NvCDqBk57mtiUTJXQQ8Z8S/4UiRQP8RG8snuCFQUs9xxdIfvl2FWIvgiBz+SMByyjTaRX42Q==
+  dependencies:
+    debug "^4.1.1"
+
 "@azure/msal-node@^1.3.0", "@azure/msal-node@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.3.2.tgz#17665397c04b9cad57b42eb6e21d5d6f35d9b83a"
   integrity sha512-aKU2lVRKhZa1IJ/Za/Ir6qlythQ3FHz0g0px3SbM4iC1otyr3ANS4mIn/6fmkpZDIHc8eAgJh2KMep1Yn2zpig==
   dependencies:
     "@azure/msal-common" "^5.0.1"
+    axios "^0.21.4"
+    jsonwebtoken "^8.5.1"
+    uuid "^8.3.0"
+
+"@azure/msal-node@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-1.4.0.tgz#660685804fbdc533b10cc699f16323e27ec582c6"
+  integrity sha512-Ek6hqOFUi5QEAxZ55awM8y1N+9SzS9Qh8ijF4RDLtFuHzqP7xXmMnVC1lae45FlH55DUOo7dg/smuDJnb4kw6g==
+  dependencies:
+    "@azure/msal-common" "^5.2.0"
     axios "^0.21.4"
     jsonwebtoken "^8.5.1"
     uuid "^8.3.0"
@@ -8251,9 +8268,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 marked@>=2.0.0, marked@^2.0.0:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
-  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.6.tgz#cd199503102b6807354f00574348d41ad4fd25d2"
+  integrity sha512-+H0bTf8DM8zLuFBUm/2VklxaCrwlBFgoJzHJcMZCnZ9cPgsllHwKpL6TPLdDeA38yPluMuVKOL1hO5w6HmG5Mg==
 
 match-all@^1.2.6:
   version "1.2.6"


### PR DESCRIPTION
#### Details

Add authentication to the storage API client

##### Motivation

Allow the storage client to access the API now that it is authenticated

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
