### PR TITLE
Fix delete resources script

### DIFF
--- a/packages/resource-deployment/scripts/delete-resource-group.sh
+++ b/packages/resource-deployment/scripts/delete-resource-group.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 exitWithUsageInfo() {
     # shellcheck disable=SC2128
     echo "
-        Usage: ${BASH_SOURCE} -r <resource group name> [-p <purge key vault if set to true>]
+        Usage: ${BASH_SOURCE} -r <resource group name> [-p <purge key vault if flag is present>]
     "
     exit 1
 }
@@ -40,7 +40,7 @@ getResourcesToDelete() {
 }
 
 deleteResources() {
-    local deleteTimeout=1800
+    local deleteTimeout=2700
     local end=$((SECONDS + deleteTimeout))
 
     getResourcesToDelete
@@ -94,10 +94,10 @@ deleteResourceGroup() {
 }
 
 # Read script arguments
-while getopts ":r:p:" option; do
+while getopts ":r:p" option; do
     case ${option} in
     r) resourceGroupName=${OPTARG} ;;
-    p) purgeKeyVault=${OPTARG} ;;
+    p) purgeKeyVault=true ;;
     *) exitWithUsageInfo ;;
     esac
 done


### PR DESCRIPTION
#### Details

The delete-resource-group.sh script was added as a placeholder during the initial process of setting up installation scripts. It was never actually implemented beyond some log statements, because we had no resources to delete at the time, and none of our automated pipelines used the script. This PR adds the implementation to make sure this script works as intended.

##### Motivation

This will allow the selftest pipeline to work as intended, and delete the existing selftest resource group before running a fresh deployment.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
