### PR TITLE
E2E Tests for REST API

### DIFF
--- a/packages/e2e-test-runner/src/e2e-test-runner.spec.ts
+++ b/packages/e2e-test-runner/src/e2e-test-runner.spec.ts
@@ -13,12 +13,14 @@ import { TestContainerFactory } from './functional-tests/test-container-factory'
 import { TestRunner } from './functional-tests/test-runner';
 import { FinalizerTestGroup } from './functional-tests/test-groups/finalizer-test-group';
 import { getPromisableDynamicMock } from './test-utilities/promisable-mock';
+import { TestScanHandler } from './test-scenarios/test-scan-handler';
 
 describe(E2ETestRunner, () => {
     let loggerMock: IMock<ContextAwareLogger>;
     let setupHandlerMock: IMock<TestScenarioSetupHandler>;
     let testContainerFactoryMock: IMock<TestContainerFactory>;
     let testRunnerMock: IMock<TestRunner>;
+    let testScanHandlerMock: IMock<TestScanHandler>;
     let testScenarioADriverMock: IMock<TestScenarioDriver>;
     let testScenarioBDriverMock: IMock<TestScenarioDriver>;
     let testScenarioDriverFactoryMock: IMock<TestScenarioDriverFactory>;
@@ -37,6 +39,7 @@ describe(E2ETestRunner, () => {
         setupHandlerMock = Mock.ofType<TestScenarioSetupHandler>();
         testContainerFactoryMock = Mock.ofType<TestContainerFactory>();
         testRunnerMock = Mock.ofType<TestRunner>();
+        testScanHandlerMock = Mock.ofType<TestScanHandler>();
         testScenarioADriverMock = Mock.ofType<TestScenarioDriver>();
         testScenarioBDriverMock = Mock.ofType<TestScenarioDriver>();
         testScenarioDriverFactoryMock = Mock.ofType<TestScenarioDriverFactory>();
@@ -46,6 +49,7 @@ describe(E2ETestRunner, () => {
             setupHandlerMock.object,
             testContainerFactoryMock.object,
             testRunnerMock.object,
+            testScanHandlerMock.object,
             testScenarioFactoriesStub,
             testScenarioDriverFactoryMock.object,
         );
@@ -70,12 +74,26 @@ describe(E2ETestRunner, () => {
     function setupTestScenarioDriverFactory(): void {
         testScenarioDriverFactoryMock
             .setup((t) =>
-                t(testScenarioA, loggerMock.object, setupHandlerMock.object, testContainerFactoryMock.object, testRunnerMock.object),
+                t(
+                    testScenarioA,
+                    loggerMock.object,
+                    setupHandlerMock.object,
+                    testContainerFactoryMock.object,
+                    testRunnerMock.object,
+                    testScanHandlerMock.object,
+                ),
             )
             .returns(() => testScenarioADriverMock.object);
         testScenarioDriverFactoryMock
             .setup((t) =>
-                t(testScenarioB, loggerMock.object, setupHandlerMock.object, testContainerFactoryMock.object, testRunnerMock.object),
+                t(
+                    testScenarioB,
+                    loggerMock.object,
+                    setupHandlerMock.object,
+                    testContainerFactoryMock.object,
+                    testRunnerMock.object,
+                    testScanHandlerMock.object,
+                ),
             )
             .returns(() => testScenarioBDriverMock.object);
     }

--- a/packages/e2e-test-runner/src/functional-tests/functional-test-group.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/functional-test-group.spec.ts
@@ -24,6 +24,7 @@ describe(FunctionalTestGroup, () => {
         webInsightsClientMock = Mock.ofType(WebInsightsStorageClient);
         guidGeneratorMock = Mock.ofType(GuidGenerator);
         websiteProviderMock = Mock.ofType(WebsiteProvider);
+        pageProviderMock = Mock.ofType(PageProvider);
 
         testSubject = new FunctionalTestGroupStub(
             webInsightsClientMock.object,

--- a/packages/e2e-test-runner/src/functional-tests/functional-test-group.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/functional-test-group.spec.ts
@@ -4,7 +4,7 @@
 import 'reflect-metadata';
 
 import { GuidGenerator } from 'common';
-import { WebApiErrorCodes } from 'service-library';
+import { PageProvider, WebApiErrorCodes, WebsiteProvider } from 'service-library';
 import { IMock, Mock } from 'typemoq';
 import { WebInsightsStorageClient } from 'storage-api-client';
 import { FunctionalTestGroup } from './functional-test-group';
@@ -16,13 +16,21 @@ class FunctionalTestGroupStub extends FunctionalTestGroup {}
 describe(FunctionalTestGroup, () => {
     let testSubject: FunctionalTestGroupStub;
     let webInsightsClientMock: IMock<WebInsightsStorageClient>;
+    let websiteProviderMock: IMock<WebsiteProvider>;
+    let pageProviderMock: IMock<PageProvider>;
     let guidGeneratorMock: IMock<GuidGenerator>;
 
     beforeEach(() => {
         webInsightsClientMock = Mock.ofType(WebInsightsStorageClient);
         guidGeneratorMock = Mock.ofType(GuidGenerator);
+        websiteProviderMock = Mock.ofType(WebsiteProvider);
 
-        testSubject = new FunctionalTestGroupStub(webInsightsClientMock.object, guidGeneratorMock.object);
+        testSubject = new FunctionalTestGroupStub(
+            webInsightsClientMock.object,
+            guidGeneratorMock.object,
+            websiteProviderMock.object,
+            pageProviderMock.object,
+        );
     });
 
     it('validate ensureResponseSuccessStatusCode()', async () => {

--- a/packages/e2e-test-runner/src/functional-tests/functional-test-group.ts
+++ b/packages/e2e-test-runner/src/functional-tests/functional-test-group.ts
@@ -3,13 +3,18 @@
 
 import { expect } from 'chai';
 import { getSerializableResponse, GuidGenerator, ResponseWithBodyType } from 'common';
-import { WebApiErrorCode } from 'service-library';
+import { PageProvider, WebApiErrorCode, WebsiteProvider } from 'service-library';
 import { WebInsightsStorageClient } from 'storage-api-client';
 
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
 export class FunctionalTestGroup {
-    constructor(protected readonly webInsightsClient: WebInsightsStorageClient, protected readonly guidGenerator: GuidGenerator) {}
+    constructor(
+        protected readonly webInsightsClient: WebInsightsStorageClient,
+        protected readonly guidGenerator: GuidGenerator,
+        protected readonly websiteProvider: WebsiteProvider,
+        protected readonly pageProvider: PageProvider,
+    ) {}
 
     public ensureResponseSuccessStatusCode(response: ResponseWithBodyType<unknown>, message?: string): void {
         const serializedResponse = JSON.stringify(getSerializableResponse(response));

--- a/packages/e2e-test-runner/src/functional-tests/test-container-factory.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-container-factory.spec.ts
@@ -6,6 +6,7 @@ import 'reflect-metadata';
 import { GuidGenerator } from 'common';
 import { WebInsightsStorageClient } from 'storage-api-client';
 import { IMock, Mock } from 'typemoq';
+import { PageProvider, WebsiteProvider } from 'service-library';
 import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
 import { TestContainerFactory } from './test-container-factory';
 import { FunctionalTestGroup } from './functional-test-group';
@@ -15,6 +16,8 @@ class TestGroupA extends FunctionalTestGroup {}
 describe(TestContainerFactory, () => {
     let webInsightsClientMock: IMock<WebInsightsStorageClient>;
     let guidGeneratorMock: IMock<GuidGenerator>;
+    let websiteProviderMock: IMock<WebsiteProvider>;
+    let pageProviderMock: IMock<PageProvider>;
 
     let testSubject: TestContainerFactory;
 
@@ -22,8 +25,15 @@ describe(TestContainerFactory, () => {
         webInsightsClientMock = Mock.ofType<WebInsightsStorageClient>();
         getPromisableDynamicMock(webInsightsClientMock);
         guidGeneratorMock = Mock.ofType<GuidGenerator>();
+        websiteProviderMock = Mock.ofType<WebsiteProvider>();
+        pageProviderMock = Mock.ofType<PageProvider>();
 
-        testSubject = new TestContainerFactory(async () => webInsightsClientMock.object, guidGeneratorMock.object);
+        testSubject = new TestContainerFactory(
+            async () => webInsightsClientMock.object,
+            guidGeneratorMock.object,
+            websiteProviderMock.object,
+            pageProviderMock.object,
+        );
     });
 
     it('Creates a test group object', async () => {

--- a/packages/e2e-test-runner/src/functional-tests/test-container-factory.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-container-factory.ts
@@ -3,6 +3,7 @@
 
 import { GuidGenerator } from 'common';
 import { inject, injectable } from 'inversify';
+import { PageProvider, WebsiteProvider } from 'service-library';
 import { WebInsightsClientProvider, WebInsightsServiceClientTypeNames } from 'storage-api-client';
 import { FunctionalTestGroup } from './functional-test-group';
 
@@ -14,11 +15,13 @@ export class TestContainerFactory {
         @inject(WebInsightsServiceClientTypeNames.WebInsightsClientProvider)
         private readonly webInsightsClientProvider: WebInsightsClientProvider,
         @inject(GuidGenerator) private readonly guidGenerator: GuidGenerator,
+        @inject(WebsiteProvider) private readonly websiteProvider: WebsiteProvider,
+        @inject(PageProvider) private readonly pageProvider: PageProvider,
     ) {}
 
     public async createTestContainer(TestGroupType: TestGroupConstructor): Promise<FunctionalTestGroup> {
         const webInsightsClient = await this.webInsightsClientProvider();
 
-        return new TestGroupType(webInsightsClient, this.guidGenerator);
+        return new TestGroupType(webInsightsClient, this.guidGenerator, this.websiteProvider, this.pageProvider);
     }
 }

--- a/packages/e2e-test-runner/src/functional-tests/test-context-data.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-context-data.ts
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ScanType } from 'storage-documents';
+
+export interface TestWebsiteScan {
+    scanType: ScanType;
+    scanId: string;
+}
+
 export interface TestContextData {
     websiteId: string;
-    websiteScanId?: string;
-    pageId?: string;
-    pageScanId?: string;
+    websiteScans: TestWebsiteScan[];
 }

--- a/packages/e2e-test-runner/src/functional-tests/test-decorator.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-decorator.spec.ts
@@ -10,7 +10,7 @@ import { definedTestsMetadataKey, test } from './test-decorator';
 
 class TestGroupStub extends FunctionalTestGroup {
     constructor() {
-        super(undefined, undefined);
+        super(undefined, undefined, undefined, undefined);
     }
 
     public testA(): void {

--- a/packages/e2e-test-runner/src/functional-tests/test-groups/get-website-scan-test-group.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-groups/get-website-scan-test-group.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import { WebApiErrorCodes } from 'service-library';
+import { ScanType } from 'storage-documents';
+import { TestEnvironment } from '../common-types';
+import { FunctionalTestGroup } from '../functional-test-group';
+import { TestContextData, TestWebsiteScan } from '../test-context-data';
+import { test } from '../test-decorator';
+
+export class GetWebsiteScanTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async failsWithInvalidWebsiteId(testContextData: TestContextData): Promise<void> {
+        const { scanType, scanId } = testContextData.websiteScans[0];
+        const response = await this.webInsightsClient.getWebsiteScan('invalid guid', scanType, scanId);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidScanId(testContextData: TestContextData): Promise<void> {
+        const response = await this.webInsightsClient.getWebsiteScan(testContextData.websiteId, 'a11y', 'invalid guid');
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidScanType(testContextData: TestContextData): Promise<void> {
+        const { scanId } = testContextData.websiteScans[0];
+        const response = await this.webInsightsClient.getWebsiteScan(testContextData.websiteId, 'invalid scan type' as ScanType, scanId);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidScanType, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async getScanWithId(testContextData: TestContextData): Promise<void> {
+        await Promise.all(
+            testContextData.websiteScans.map(async (websiteScan: TestWebsiteScan) => {
+                const response = await this.webInsightsClient.getWebsiteScan(
+                    testContextData.websiteId,
+                    websiteScan.scanType,
+                    websiteScan.scanId,
+                );
+
+                this.ensureResponseSuccessStatusCode(response);
+                expect(response.body.id).to.be.equal(websiteScan.scanId);
+                expect(response.body.scanType).to.be.equal(websiteScan.scanType);
+            }),
+        );
+    }
+
+    @test(TestEnvironment.all)
+    public async getLatestScan(testContextData: TestContextData): Promise<void> {
+        await Promise.all(
+            testContextData.websiteScans.map(async (websiteScan: TestWebsiteScan) => {
+                const response = await this.webInsightsClient.getLatestWebsiteScan(testContextData.websiteId, websiteScan.scanType);
+
+                this.ensureResponseSuccessStatusCode(response);
+                expect(response.body.id).to.be.equal(websiteScan.scanId);
+                expect(response.body.scanType).to.be.equal(websiteScan.scanType);
+            }),
+        );
+    }
+}

--- a/packages/e2e-test-runner/src/functional-tests/test-groups/get-website-test-group.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-groups/get-website-test-group.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { isValidWebsiteObject } from 'api-contracts';
+import { expect } from 'chai';
+import { WebApiErrorCodes } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { FunctionalTestGroup } from '../functional-test-group';
+import { TestContextData } from '../test-context-data';
+import { test } from '../test-decorator';
+
+export class GetWebsiteTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async getInvalidGuidFails(testContextData: TestContextData): Promise<void> {
+        const getWebsiteResponse = await this.webInsightsClient.getWebsite('invalid guid');
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, getWebsiteResponse);
+    }
+
+    @test(TestEnvironment.all)
+    public async getNonexistantWebsiteFails(testContextData: TestContextData): Promise<void> {
+        const newGuid = this.guidGenerator.createGuid();
+        const getWebsiteResponse = await this.webInsightsClient.getWebsite(newGuid);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.resourceNotFound, getWebsiteResponse);
+    }
+
+    @test(TestEnvironment.all)
+    public async getWebsiteSucceeds(testContextData: TestContextData): Promise<void> {
+        const getWebsiteResponse = await this.webInsightsClient.getWebsite(testContextData.websiteId);
+        this.ensureResponseSuccessStatusCode(getWebsiteResponse);
+
+        const website = getWebsiteResponse.body;
+        expect(website.id).to.be.equal(testContextData.websiteId);
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        expect(isValidWebsiteObject(website), 'get website should return a valid website').to.be.true;
+    }
+}

--- a/packages/e2e-test-runner/src/functional-tests/test-groups/post-website-scan-test-group.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-groups/post-website-scan-test-group.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ApiContracts from 'api-contracts';
+import { WebApiErrorCodes } from 'service-library';
+import { TestEnvironment } from '../common-types';
+import { FunctionalTestGroup } from '../functional-test-group';
+import { TestContextData } from '../test-context-data';
+import { test } from '../test-decorator';
+
+export class PostWebsiteScanTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async failsWithInvalidWebsiteScanRequest(testContextData: TestContextData): Promise<void> {
+        const invalidWebsiteScanRequest = { scanType: 'a11y' } as ApiContracts.WebsiteScanRequest;
+        const postWebsiteScanResponse = await this.webInsightsClient.postWebsiteScan(invalidWebsiteScanRequest);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.malformedRequest, postWebsiteScanResponse);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidWebsiteId(testContextData: TestContextData): Promise<void> {
+        const websiteScanRequest: ApiContracts.WebsiteScanRequest = {
+            websiteId: 'invalid guid',
+            scanType: 'a11y',
+        };
+
+        const postWebsiteScanResponse = await this.webInsightsClient.postWebsiteScan(websiteScanRequest);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, postWebsiteScanResponse);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithNonexistantWebsiteId(testContextData: TestContextData): Promise<void> {
+        const newGuid = this.guidGenerator.createGuid();
+        const websiteScanRequest: ApiContracts.WebsiteScanRequest = {
+            websiteId: newGuid,
+            scanType: 'a11y',
+        };
+
+        const postWebsiteScanResponse = await this.webInsightsClient.postWebsiteScan(websiteScanRequest);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.resourceNotFound, postWebsiteScanResponse);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidPriority(testContextData: TestContextData): Promise<void> {
+        const invalidPriorities = [9999, -9999];
+        await Promise.all(
+            invalidPriorities.map(async (priority) => {
+                const websiteScanRequest: ApiContracts.WebsiteScanRequest = {
+                    websiteId: testContextData.websiteId,
+                    scanType: 'a11y',
+                    priority: priority,
+                };
+
+                const postWebsiteScanResponse = await this.webInsightsClient.postWebsiteScan(websiteScanRequest);
+
+                this.expectWebApiErrorResponse(WebApiErrorCodes.outOfRangePriority, postWebsiteScanResponse);
+            }),
+        );
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidCronExpression(testContextData: TestContextData): Promise<void> {
+        const websiteScanRequest: ApiContracts.WebsiteScanRequest = {
+            websiteId: testContextData.websiteId,
+            scanType: 'a11y',
+            scanFrequency: 'invalid cron expression',
+        };
+
+        const postWebsiteScanResponse = await this.webInsightsClient.postWebsiteScan(websiteScanRequest);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidFrequencyExpression, postWebsiteScanResponse);
+    }
+}

--- a/packages/e2e-test-runner/src/functional-tests/test-groups/post-website-test-group.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-groups/post-website-test-group.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ApiContracts from 'api-contracts';
+import { expect } from 'chai';
+import { websiteWithRequiredProperties } from 'api-contracts';
+import { WebApiErrorCodes } from 'service-library';
+import { Website } from 'storage-documents';
+import _ from 'lodash';
+import { TestEnvironment } from '../common-types';
+import { FunctionalTestGroup } from '../functional-test-group';
+import { TestContextData } from '../test-context-data';
+import { test } from '../test-decorator';
+
+export class PostWebsiteTestGroup extends FunctionalTestGroup {
+    @test(TestEnvironment.all)
+    public async failsWithInvalidWebsite(testContextData: TestContextData): Promise<void> {
+        const response = await this.webInsightsClient.postWebsite({ name: 'invalid website' } as Website);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.malformedRequest, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithDisallowedWebsiteProperties(testContextData: TestContextData): Promise<void> {
+        const website = _.cloneDeep(websiteWithRequiredProperties);
+        website.pages = [{ id: 'page id', url: 'http://pageurl.com/' }];
+        const response = await this.webInsightsClient.postWebsite(website);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.malformedRequest, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async failsWithInvalidGuid(testContextData: TestContextData): Promise<void> {
+        const website = _.cloneDeep(websiteWithRequiredProperties);
+        website.id = 'invalid guid';
+        const response = await this.webInsightsClient.postWebsite(website);
+
+        this.expectWebApiErrorResponse(WebApiErrorCodes.invalidResourceId, response);
+    }
+
+    @test(TestEnvironment.all)
+    public async postNewWebsite(testContextData: TestContextData): Promise<void> {
+        const testWebsiteResponse = await this.webInsightsClient.getWebsite(testContextData.websiteId);
+        this.ensureResponseSuccessStatusCode(testWebsiteResponse);
+
+        const newTestWebsite = _.omit(testWebsiteResponse.body, ['id', 'pages']);
+
+        let newWebsite: ApiContracts.Website;
+
+        // try/catch/finally ensures we will always clean up the new website
+        try {
+            const newWebsiteResponse = await this.webInsightsClient.postWebsite(newTestWebsite);
+            this.ensureResponseSuccessStatusCode(newWebsiteResponse);
+
+            newWebsite = newWebsiteResponse.body;
+            expect(newWebsiteResponse.statusCode).to.be.equal(201);
+            expect(newWebsiteResponse.body).deep.include(newTestWebsite);
+            expect(newWebsiteResponse.body.pages, 'Expect post website to create a page document for each knownPage url').to.be.length(
+                newTestWebsite.knownPages.length,
+            );
+            // eslint-disable-next-line no-useless-catch
+        } catch (e) {
+            throw e;
+        } finally {
+            if (newWebsite !== undefined) {
+                await Promise.all(newWebsite.pages.map((page) => this.pageProvider.deletePage(page.id)));
+                await this.websiteProvider.deleteWebsite(newWebsite.id);
+            }
+        }
+    }
+
+    @test(TestEnvironment.all)
+    public async postExistingWebsite(testContextData: TestContextData): Promise<void> {
+        const testWebsiteResponse = await this.webInsightsClient.getWebsite(testContextData.websiteId);
+        this.ensureResponseSuccessStatusCode(testWebsiteResponse);
+
+        const websiteName = testWebsiteResponse.body.name;
+        const updatedWebsiteName = `${websiteName} - updated`;
+        const websiteUpdate: ApiContracts.Website = {
+            ...testWebsiteResponse.body,
+            pages: undefined,
+            name: updatedWebsiteName,
+        };
+
+        const postWebsiteResponse = await this.webInsightsClient.postWebsite(websiteUpdate);
+        this.ensureResponseSuccessStatusCode(postWebsiteResponse);
+
+        expect(postWebsiteResponse.statusCode).to.be.equal(200);
+        expect(postWebsiteResponse.body).deep.include(_.omit(websiteUpdate, 'pages'));
+    }
+}

--- a/packages/e2e-test-runner/src/functional-tests/test-runner.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-runner.spec.ts
@@ -33,7 +33,7 @@ class TestGroupWithContext extends TestGroupStubBase {
     @test(TestEnvironment.all)
     public async testContextData(testContextData: TestContextData): Promise<void> {
         expect(testContextData).toBeDefined();
-        expect(testContextData).toEqual({ websiteId: 'website id' });
+        expect(testContextData).toEqual({ websiteId: 'website id', websiteScans: [] });
     }
 }
 
@@ -69,7 +69,7 @@ describe(TestRunner, () => {
     const runId = 'run id';
     const releaseId = 'release id';
     const scenarioName = 'scenarioName';
-    const testContextData: TestContextData = { websiteId: 'website id' };
+    const testContextData: TestContextData = { websiteId: 'website id', websiteScans: [] };
     let testContainerA: TestGroupAStub;
     let testContainerB: TestGroupBStub;
     let testContainerAName: string;
@@ -156,7 +156,7 @@ describe(TestRunner, () => {
             logSource: 'TestContainer',
         });
 
-        await testRunner.runAll([testContainerA, testContainerB], { scenarioName }, { websiteId: 'website id' });
+        await testRunner.runAll([testContainerA, testContainerB], { scenarioName }, { websiteId: 'website id', websiteScans: [] });
     });
 
     it('run tests for the given environment only', async () => {

--- a/packages/e2e-test-runner/src/functional-tests/test-runner.spec.ts
+++ b/packages/e2e-test-runner/src/functional-tests/test-runner.spec.ts
@@ -17,7 +17,7 @@ import { TestContextData } from './test-context-data';
 
 class TestGroupStubBase extends FunctionalTestGroup {
     constructor() {
-        super(undefined, undefined);
+        super(undefined, undefined, undefined, undefined);
     }
 }
 

--- a/packages/e2e-test-runner/src/test-scenarios/test-scan-handler.spec.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scan-handler.spec.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import 'reflect-metadata';
+
+import * as ApiContracts from 'api-contracts';
+import { WebInsightsStorageClient } from 'storage-api-client';
+import { IMock, Mock } from 'typemoq';
+import { ResponseWithBodyType } from 'common';
+import { getPromisableDynamicMock } from '../test-utilities/promisable-mock';
+import { TestScanHandler } from './test-scan-handler';
+
+describe(TestScanHandler, () => {
+    let webInsightsClientMock: IMock<WebInsightsStorageClient>;
+    const currentDate = new Date(0, 0, 2, 3, 4, 5); // year, month(0-indexed), day, hour, minute, second
+    const scanType = 'a11y';
+    const websiteId = 'website id';
+
+    let testSubject: TestScanHandler;
+
+    beforeEach(() => {
+        webInsightsClientMock = Mock.ofType<WebInsightsStorageClient>();
+        getPromisableDynamicMock(webInsightsClientMock);
+
+        testSubject = new TestScanHandler(
+            async () => webInsightsClientMock.object,
+            () => currentDate,
+        );
+    });
+
+    it('submitTestScan posts a website scan with expected properties', async () => {
+        const expectedScanRequest: ApiContracts.WebsiteScanRequest = {
+            websiteId,
+            scanType,
+            scanFrequency: '5 4 3 2 1 ?', // second, minute, hour, day, month (1-indexed), day-of-week
+        };
+        const response = { statusCode: 201 } as ResponseWithBodyType<ApiContracts.WebsiteScan>;
+
+        webInsightsClientMock
+            .setup((c) => c.postWebsiteScan(expectedScanRequest))
+            .returns(async () => response)
+            .verifiable();
+
+        const actualResponse = await testSubject.submitTestScan(scanType, websiteId);
+
+        expect(actualResponse).toBe(response);
+    });
+});

--- a/packages/e2e-test-runner/src/test-scenarios/test-scan-handler.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scan-handler.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as ApiContracts from 'api-contracts';
+import { ResponseWithBodyType } from 'common';
+import { inject, injectable } from 'inversify';
+import { WebInsightsClientProvider, WebInsightsServiceClientTypeNames } from 'storage-api-client';
+import { ScanType } from 'storage-documents';
+
+@injectable()
+export class TestScanHandler {
+    constructor(
+        @inject(WebInsightsServiceClientTypeNames.WebInsightsClientProvider)
+        private readonly webInsightsClientProvider: WebInsightsClientProvider,
+        private readonly getCurrentDate: () => Date = () => new Date(),
+    ) {}
+
+    public async submitTestScan(scanType: ScanType, websiteId: string): Promise<ResponseWithBodyType<ApiContracts.WebsiteScan>> {
+        const scanRequest: ApiContracts.WebsiteScanRequest = {
+            websiteId: websiteId,
+            scanType: scanType,
+            scanFrequency: this.createCronExpressionFromDatetime(this.getCurrentDate()),
+        };
+        const webInsightsClient = await this.webInsightsClientProvider();
+
+        return webInsightsClient.postWebsiteScan(scanRequest);
+    }
+
+    private createCronExpressionFromDatetime(datetime: Date): string {
+        const second = datetime.getSeconds();
+        const minute = datetime.getMinutes();
+        const hour = datetime.getHours();
+        const dayOfMonth = datetime.getDate();
+        const month = datetime.getMonth() + 1; // cron-parser uses 1-indexed months while Date uses 0-indexed months
+
+        return `${second} ${minute} ${hour} ${dayOfMonth} ${month} ?`;
+    }
+}

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-definitions.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-definitions.ts
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 import { TestGroupConstructor } from '../functional-tests/test-container-factory';
+import { GetWebsiteTestGroup } from '../functional-tests/test-groups/get-website-test-group';
+import { PostWebsiteScanTestGroup } from '../functional-tests/test-groups/post-website-scan-test-group';
+import { PostWebsiteTestGroup } from '../functional-tests/test-groups/post-website-test-group';
 
 export type TestPhases = {
     beforeScan: TestGroupConstructor[];
@@ -21,7 +24,7 @@ export const allTestScenarioFactories: TestScenarioDefinitionFactory[] = [
             readableName: 'SimpleScan ',
             websiteDataBlobName: 'test-website.json',
             testPhases: {
-                beforeScan: [],
+                beforeScan: [GetWebsiteTestGroup, PostWebsiteTestGroup, PostWebsiteScanTestGroup],
             },
         };
     },

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-definitions.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-definitions.ts
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ScanType } from 'storage-documents';
 import { TestGroupConstructor } from '../functional-tests/test-container-factory';
+import { GetWebsiteScanTestGroup } from '../functional-tests/test-groups/get-website-scan-test-group';
 import { GetWebsiteTestGroup } from '../functional-tests/test-groups/get-website-test-group';
 import { PostWebsiteScanTestGroup } from '../functional-tests/test-groups/post-website-scan-test-group';
 import { PostWebsiteTestGroup } from '../functional-tests/test-groups/post-website-test-group';
 
 export type TestPhases = {
     beforeScan: TestGroupConstructor[];
+    afterScanSubmission: TestGroupConstructor[];
 };
 
 export type TestScenarioDefinition = {
     readableName: string;
     websiteDataBlobName: string;
     testPhases: Partial<TestPhases>;
+    scansToRun: ScanType[];
 };
 
 export type TestScenarioDefinitionFactory = () => TestScenarioDefinition;
@@ -25,7 +29,9 @@ export const allTestScenarioFactories: TestScenarioDefinitionFactory[] = [
             websiteDataBlobName: 'test-website.json',
             testPhases: {
                 beforeScan: [GetWebsiteTestGroup, PostWebsiteTestGroup, PostWebsiteScanTestGroup],
+                afterScanSubmission: [GetWebsiteScanTestGroup],
             },
+            scansToRun: ['a11y'],
         };
     },
 ];

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-driver.spec.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-driver.spec.ts
@@ -3,8 +3,11 @@
 
 import 'reflect-metadata';
 
+import * as ApiContracts from 'api-contracts';
 import { ContextAwareLogger, Logger } from 'logger';
 import { IMock, It, Mock, Times } from 'typemoq';
+import { ScanType } from 'storage-documents';
+import { ResponseWithBodyType } from 'common';
 import { TestContextData } from '../functional-tests/test-context-data';
 import { TestContainerFactory } from '../functional-tests/test-container-factory';
 import { FunctionalTestGroup } from '../functional-tests/functional-test-group';
@@ -13,6 +16,7 @@ import { TestPhases, TestScenarioDefinition } from './test-scenario-definitions'
 
 import { TestScenarioDriver } from './test-scenario-driver';
 import { TestScenarioSetupHandler } from './test-scenario-setup-handler';
+import { TestScanHandler } from './test-scan-handler';
 
 class TestableTestScenarioDriver extends TestScenarioDriver {
     public testContextData: TestContextData;
@@ -24,11 +28,14 @@ class TestContainerB extends FunctionalTestGroup {}
 
 describe(TestScenarioDriver, () => {
     let testScenarioDefinition: TestScenarioDefinition;
-    const initialTestContextData = { websiteId: 'website id' };
+    const websiteId = 'website id';
+    const websiteScanId = 'website scan id';
+    const initialTestContextData = { websiteId };
     let loggerMock: IMock<Logger>;
     let setupHandlerMock: IMock<TestScenarioSetupHandler>;
     let testContainerFactoryMock: IMock<TestContainerFactory>;
     let testRunnerMock: IMock<TestRunner>;
+    let testScanHandlerMock: IMock<TestScanHandler>;
 
     let testSubject: TestableTestScenarioDriver;
 
@@ -44,6 +51,7 @@ describe(TestScenarioDriver, () => {
         setupHandlerMock = Mock.ofType<TestScenarioSetupHandler>();
         testContainerFactoryMock = Mock.ofType<TestContainerFactory>();
         testRunnerMock = Mock.ofType<TestRunner>();
+        testScanHandlerMock = Mock.ofType<TestScanHandler>();
 
         testSubject = new TestableTestScenarioDriver(
             testScenarioDefinition,
@@ -51,6 +59,7 @@ describe(TestScenarioDriver, () => {
             setupHandlerMock.object,
             testContainerFactoryMock.object,
             testRunnerMock.object,
+            testScanHandlerMock.object,
         );
     });
 
@@ -59,40 +68,53 @@ describe(TestScenarioDriver, () => {
         setupHandlerMock.verifyAll();
         testContainerFactoryMock.verifyAll();
         testRunnerMock.verifyAll();
+        testScanHandlerMock.verifyAll();
     });
 
     it('handles and logs setup error', async () => {
         const testError = new Error();
-        const expectedLogProperties = {
-            testScenarioName: testScenarioDefinition.readableName,
-            error: JSON.stringify(testError),
-        };
         setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).throws(testError);
-        loggerMock.setup((l) => l.logError(It.isAny(), expectedLogProperties)).verifiable();
+        setupLogFailure();
         setupTestRunnerNeverCalled();
 
         await testSubject.executeTestScenario();
     });
 
     it('handles empty test phase', async () => {
-        setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
         testScenarioDefinition.testPhases.beforeScan = [];
+        setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
         setupTestRunnerNeverCalled();
+        setupFailedScanSubmission(It.isAny());
 
         await testSubject.executeTestScenario();
     });
 
     it('handles undefined test phase', async () => {
-        setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
         testScenarioDefinition.testPhases.beforeScan = undefined;
+        setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
         setupTestRunnerNeverCalled();
+        setupFailedScanSubmission(It.isAny());
 
         await testSubject.executeTestScenario();
     });
 
-    it('calls setup handler and runs beforeScanPhase', async () => {
+    it.each([{ statusCode: 404 }, { statusCode: 204, body: undefined }] as ResponseWithBodyType<ApiContracts.WebsiteScan>[])(
+        'logs error if scan submission returns %s',
+        async (errorResponse) => {
+            setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
+            setupRunTestPhase('beforeScan');
+            setupFailedScanSubmission('a11y', errorResponse);
+            setupLogFailure();
+
+            await testSubject.executeTestScenario();
+        },
+    );
+
+    it('executes all steps and tracks availability if no failures', async () => {
         setupHandlerMock.setup((s) => s.setUpTestScenario(testScenarioDefinition)).returns(async () => initialTestContextData);
         setupRunTestPhase('beforeScan');
+        setupSuccessfulScanSubmission('a11y');
+        loggerMock.setup((l) => l.trackAvailability('workerAvailabilityTest', It.isObjectWith({ success: true }))).verifiable();
 
         await testSubject.executeTestScenario();
     });
@@ -117,5 +139,26 @@ describe(TestScenarioDriver, () => {
     function setupTestRunnerNeverCalled(): void {
         testRunnerMock.setup((tr) => tr.runAll(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
         testRunnerMock.setup((tr) => tr.run(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+    }
+
+    function setupLogFailure(): void {
+        loggerMock.setup((l) => l.logError(It.isAny(), It.isAny())).verifiable();
+        loggerMock.setup((l) => l.trackAvailability('workerAvailabilityTest', It.isObjectWith({ success: false }))).verifiable();
+        loggerMock.setup((l) => l.trackAvailability(It.isAny(), It.isObjectWith({ success: true }))).verifiable(Times.never());
+    }
+
+    function setupSuccessfulScanSubmission(scanType: ScanType): void {
+        const response = {
+            statusCode: 201,
+            body: {
+                id: websiteScanId,
+            },
+        } as ResponseWithBodyType<ApiContracts.WebsiteScan>;
+        testScanHandlerMock.setup((t) => t.submitTestScan(scanType, websiteId)).returns(async () => response);
+    }
+
+    function setupFailedScanSubmission(scanType: ScanType, errorResponse?: ResponseWithBodyType<ApiContracts.WebsiteScan>): void {
+        const response = errorResponse ?? ({ statusCode: 404 } as ResponseWithBodyType<ApiContracts.WebsiteScan>);
+        testScanHandlerMock.setup((t) => t.submitTestScan(scanType, websiteId)).returns(async () => response);
     }
 });

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-driver.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-driver.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { client } from 'azure-services';
+import { getSerializableResponse } from 'common';
 import _ from 'lodash';
-import { Logger } from 'logger';
+import { Logger, LoggerProperties } from 'logger';
+import { ScanType } from 'storage-documents';
 import { TestContainerFactory } from '../functional-tests/test-container-factory';
 import { TestContextData } from '../functional-tests/test-context-data';
 import { TestRunner } from '../functional-tests/test-runner';
+import { TestScanHandler } from './test-scan-handler';
 import { TestPhases, TestScenarioDefinition } from './test-scenario-definitions';
 import { TestScenarioSetupHandler } from './test-scenario-setup-handler';
 
@@ -18,21 +22,26 @@ export class TestScenarioDriver {
         private readonly testScenarioSetupHandler: TestScenarioSetupHandler,
         private readonly testContainerFactory: TestContainerFactory,
         private readonly testRunner: TestRunner,
+        private readonly testScanHandler: TestScanHandler,
     ) {}
 
     public async executeTestScenario(): Promise<void> {
         try {
             this.testContextData = await this.testScenarioSetupHandler.setUpTestScenario(this.testScenarioDefinition);
         } catch (e) {
-            this.logger.logError('Failed to set up test scenario.', {
-                testScenarioName: this.testScenarioDefinition.readableName,
-                error: JSON.stringify(e),
-            });
+            this.logTestFailure('Failed to set up test scenario.', { error: JSON.stringify(e) });
 
             return;
         }
 
         await this.runTestPhase('beforeScan');
+
+        const submitScanSucceeded = await this.trySubmitScan('a11y');
+        if (!submitScanSucceeded) {
+            return;
+        }
+
+        await this.logTestSuccess();
     }
 
     private async runTestPhase(phaseName: keyof TestPhases): Promise<void> {
@@ -45,5 +54,53 @@ export class TestScenarioDriver {
         );
 
         await this.testRunner.runAll(testContainers, { scenarioName: this.testScenarioDefinition.readableName }, this.testContextData);
+    }
+
+    private async trySubmitScan(scanType: ScanType): Promise<boolean> {
+        const submitScanResponse = await this.testScanHandler.submitTestScan(scanType, this.testContextData.websiteId);
+        if (!client.isSuccessStatusCode(submitScanResponse) || submitScanResponse.body === undefined) {
+            this.logTestFailure('Failed to submit a11y scan', {
+                requestResponse: JSON.stringify(getSerializableResponse(submitScanResponse)),
+            });
+
+            return false;
+        }
+        this.testContextData.websiteScanId = submitScanResponse.body.id;
+
+        return true;
+    }
+
+    private getBaseTelemetryProperties(): LoggerProperties {
+        return {
+            testScenarioName: this.testScenarioDefinition.readableName,
+            websiteId: this.testContextData?.websiteId,
+            websiteScanId: this.testContextData?.websiteScanId,
+        };
+    }
+
+    private logTestFailure(errorMessage: string, telemetryProperties: LoggerProperties): void {
+        this.logger.logError(errorMessage, {
+            ...this.getBaseTelemetryProperties(),
+            ...telemetryProperties,
+        });
+        this.logger.trackAvailability('workerAvailabilityTest', {
+            success: false,
+            properties: {
+                ...this.getBaseTelemetryProperties(),
+                ...telemetryProperties,
+            },
+        });
+    }
+
+    private logTestSuccess(): void {
+        this.logger.logInfo('Successfully completed test scenario', {
+            ...this.getBaseTelemetryProperties(),
+        });
+        this.logger.trackAvailability('workerAvailabilityTest', {
+            success: true,
+            properties: {
+                ...this.getBaseTelemetryProperties(),
+            },
+        });
     }
 }

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-setup-handler.spec.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-setup-handler.spec.ts
@@ -69,6 +69,6 @@ describe(TestScenarioSetupHandler, () => {
 
         const testContextData = await testSubject.setUpTestScenario(testScenario);
 
-        expect(testContextData).toEqual({ websiteId: website.id });
+        expect(testContextData).toEqual({ websiteId: website.id, websiteScans: [] });
     });
 });

--- a/packages/e2e-test-runner/src/test-scenarios/test-scenario-setup-handler.ts
+++ b/packages/e2e-test-runner/src/test-scenarios/test-scenario-setup-handler.ts
@@ -21,7 +21,7 @@ export class TestScenarioSetupHandler {
         const websiteBlob = await this.readTestWebsiteBlob(testScenario);
         const postedWebsite = await this.postTestWebsite(websiteBlob);
 
-        return { websiteId: postedWebsite.id };
+        return { websiteId: postedWebsite.id, websiteScans: [] };
     }
 
     private async readTestWebsiteBlob(testScenario: TestScenarioDefinition): Promise<ApiContracts.Website> {

--- a/packages/resource-deployment/e2e-test-data/test-website.json
+++ b/packages/resource-deployment/e2e-test-data/test-website.json
@@ -1,0 +1,18 @@
+{
+    "id": "1ec15992-4a5a-6da0-67d2-a744ded46dcd",
+    "name": "Test website",
+    "baseUrl": "https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-05-04/",
+    "priority": 0,
+    "discoveryPatterns": [],
+    "knownPages": ["https://teststorage57bzoqjjclekk.z13.web.core.windows.net/2021-05-04/linked1/"],
+    "scanners": ["a11y"],
+    "domainId": "domain id",
+    "compliant": false,
+    "enableCrawler": true,
+    "deleted": false,
+    "noBanner": true,
+    "serviceTreeId": "service tree id",
+    "isCustomBanner": false,
+    "isMicrosoftOwned": false,
+    "isCookieManagable": false
+}

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -32,16 +32,6 @@ waitForAppGatewayUpdate() {
     fi
 }
 
-enableAppGatewayAutoscale() {
-    local minCapacity=2
-    local maxCapacity=5
-    echo "Configuring autoscale for application gateway"
-    az network application-gateway update --name "${appGateway}" --resource-group "${vnetResourceGroup}" \
-        --set sku='{"capacity": null, "name": "Standard_v2", "tier": "Standard_v2"}' \
-        --set autoscaleConfiguration="{\"minCapacity\": ${minCapacity}, \"maxCapacity\": ${maxCapacity}}" \
-        1>/dev/null
-}
-
 grantAccessToAppGateway() {
     echo "Granting access to application gateway"
     az network application-gateway identity assign --gateway-name "${appGateway}" --resource-group "${vnetResourceGroup}" --identity "${appGatewayIdentity}" 1>/dev/null
@@ -124,7 +114,6 @@ vnetResourceGroup=$(az aks list --resource-group "${resourceGroupName}" --query 
 
 waitForAppGatewayUpdate
 attachContainerRegistry
-enableAppGatewayAutoscale
 grantAccessToAppGateway
 
 echo "Azure Kubernetes Service successfully created."

--- a/packages/resource-deployment/scripts/create-kubernetes-service.sh
+++ b/packages/resource-deployment/scripts/create-kubernetes-service.sh
@@ -32,6 +32,16 @@ waitForAppGatewayUpdate() {
     fi
 }
 
+enableAppGatewayAutoscale() {
+    local minCapacity=2
+    local maxCapacity=5
+    echo "Configuring autoscale for application gateway"
+    az network application-gateway update --name "${appGateway}" --resource-group "${vnetResourceGroup}" \
+        --set sku='{"capacity": null, "name": "Standard_v2", "tier": "Standard_v2"}' \
+        --set autoscaleConfiguration="{\"minCapacity\": ${minCapacity}, \"maxCapacity\": ${maxCapacity}}" \
+        1>/dev/null
+}
+
 grantAccessToAppGateway() {
     echo "Granting access to application gateway"
     az network application-gateway identity assign --gateway-name "${appGateway}" --resource-group "${vnetResourceGroup}" --identity "${appGatewayIdentity}" 1>/dev/null
@@ -114,6 +124,7 @@ vnetResourceGroup=$(az aks list --resource-group "${resourceGroupName}" --query 
 
 waitForAppGatewayUpdate
 attachContainerRegistry
+enableAppGatewayAutoscale
 grantAccessToAppGateway
 
 echo "Azure Kubernetes Service successfully created."

--- a/packages/service-library/src/data-providers/page-provider.spec.ts
+++ b/packages/service-library/src/data-providers/page-provider.spec.ts
@@ -63,6 +63,14 @@ describe(PageProvider, () => {
         });
     });
 
+    describe('deletePage', () => {
+        it('deletes page doc', async () => {
+            cosmosContainerClientMock.setup((c) => c.deleteDocument(pageId, partitionKey)).verifiable();
+
+            await testSubject.deletePage(pageId);
+        });
+    });
+
     describe('updatePage', () => {
         it('throws if no id', () => {
             const pageData: Partial<Page> = {

--- a/packages/service-library/src/data-providers/page-provider.ts
+++ b/packages/service-library/src/data-providers/page-provider.ts
@@ -29,6 +29,10 @@ export class PageProvider {
         return pageDoc;
     }
 
+    public async deletePage(pageId: string): Promise<void> {
+        await this.cosmosContainerClient.deleteDocument(pageId, this.getPagePartitionKey(pageId));
+    }
+
     public async updatePage(page: Partial<Page>): Promise<Page> {
         const response = await this.cosmosContainerClient.mergeOrWriteDocument<Page>(this.normalizeDbDocument(page) as Page);
 

--- a/packages/service-library/src/data-providers/website-provider.spec.ts
+++ b/packages/service-library/src/data-providers/website-provider.spec.ts
@@ -61,6 +61,14 @@ describe(WebsiteProvider, () => {
         });
     });
 
+    describe('deleteWebsite', () => {
+        it('deletes document', async () => {
+            cosmosContainerClientMock.setup((c) => c.deleteDocument(websiteId, PartitionKey.websiteDocuments)).verifiable();
+
+            await testSubject.deleteWebsite(websiteId);
+        });
+    });
+
     describe('updateWebsite', () => {
         it('throws if no id', () => {
             const websiteData: Partial<Website> = {

--- a/packages/service-library/src/data-providers/website-provider.ts
+++ b/packages/service-library/src/data-providers/website-provider.ts
@@ -21,6 +21,10 @@ export class WebsiteProvider {
         return websiteDoc as Website;
     }
 
+    public async deleteWebsite(websiteId: string): Promise<void> {
+        await this.cosmosContainerClient.deleteDocument(websiteId, PartitionKey.websiteDocuments);
+    }
+
     public async updateWebsite(website: Partial<Website>): Promise<Website> {
         const websiteDoc = this.normalizeDbDocument(website);
 


### PR DESCRIPTION
#### Details

Adds E2E tests for the storage REST API

##### Motivation

This will enable us to continuously monitor for availability and expected behavior of the frontend API

##### Context

To try to minimize the number of throwaway documents created in the testing process, only one website and one website scan are used for most tests. The main test website document is reused between test runs. One new additional website is created on each test run to validate website creation, and then the website document and page documents are deleted.

One website scan is also created per test run, with "frequency" set to a cron expression that will run only once (or once yearly, if the document isn't cleaned up in that time, since cron-parser doesn't accept years in cron expressions). The website scan document is not deleted, since spontaneously disappearing scan documents would likely cause problems when the backend scheduler and scanner are implemented.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
