### PR TITLE
Use same time range for all dashboard tiles

### DIFF
--- a/packages/resource-deployment/templates/dashboard.template.json
+++ b/packages/resource-deployment/templates/dashboard.template.json
@@ -174,15 +174,6 @@
                                                 }
                                             }
                                         }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "60m"
-                                            }
-                                        }
                                     }
                                 }
                             },
@@ -498,13 +489,6 @@
                                                 "operator": "equals",
                                                 "values": ["FunctionalTest"]
                                             }
-                                        },
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "1440m"
-                                            }
                                         }
                                     }
                                 }
@@ -592,15 +576,6 @@
                                                 }
                                             }
                                         }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "60m"
-                                            }
-                                        }
                                     }
                                 }
                             },
@@ -681,15 +656,6 @@
                                                         "openBlade": true
                                                     }
                                                 }
-                                            }
-                                        }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "60m"
                                             }
                                         }
                                     }
@@ -809,15 +775,6 @@
                                                 }
                                             }
                                         }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "1440m"
-                                            }
-                                        }
                                     }
                                 }
                             },
@@ -989,15 +946,6 @@
                                                         "disablePinning": true
                                                     }
                                                 }
-                                            }
-                                        }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "1440m"
                                             }
                                         }
                                     }
@@ -1127,15 +1075,6 @@
                                                         "disablePinning": true
                                                     }
                                                 }
-                                            }
-                                        }
-                                    },
-                                    "filters": {
-                                        "MsPortalFx_TimeRange": {
-                                            "model": {
-                                                "format": "local",
-                                                "granularity": "auto",
-                                                "relative": "1440m"
                                             }
                                         }
                                     }


### PR DESCRIPTION
#### Details

Remove tile-level time filters on dashboard tiles

##### Motivation

This will ensure that all dashboard tiles show the same timerange

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Validated in an Azure resource group
